### PR TITLE
feat: add `editRepoBaseUrl` config and `-R, --edit-repo` cli flag support

### DIFF
--- a/.changeset/silent-moles-yell.md
+++ b/.changeset/silent-moles-yell.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+feat: add `editRepoBaseUrl` config and `-R, --edit-repo` cli flag support

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,7 +37,7 @@ jobs:
           # copy the pdf to the tempdir
           cp -r ./dist/*.pdf $tempdir
           # then build the docs with pdf download link
-          yarn docs:build -d
+          yarn docs:build -d -R
           # copy the pdf back to the dist folder
           cp -r $tempdir/*.pdf ./dist
           # remove the tempdir

--- a/docs/start.mdx
+++ b/docs/start.mdx
@@ -96,6 +96,7 @@ Options:
   -E, --exclude <language...>     Include all languages except the specific language(s), `ru` for example
   -o, --out-dir <path>            Override the `outDir` defined in the config file or the default `dist/{base}/{version}`, the resulting path will be `dist/{outDir}/{version}`
   -r, --redirect <enum>           Whether to redirect to the locale closest to `navigator.language` when the user visits the site, could be `auto`, `never` or `only-default-lang` (default: "only-default-lang")
+  -R, --edit-repo [boolean|url]   Whether to enable or override the `editRepoBaseUrl` config feature, `https://github.com/` prefix could be omitted (default: false)
   -n, --no-open [boolean]         Do not open the browser after starting the server
   -h, --help                      display help for command
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -202,3 +202,9 @@ translate:
 <%= additionalPrompts %>
   userPrompt: # 可选，用于填充到 `systemPrompt` 中的 `ejs` 模板全局参数
 ```
+
+## 在代码仓库编辑文档 \{#edit-repo}
+
+```yaml
+editRepoBaseUrl: alauda/doom/tree/main/docs # https://github.com/ 前缀可以省略，仅当启用 `-R, --edit-repo` 命令行标志符时生效
+```

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -19,3 +19,4 @@ reference:
         path: docs/usage/configuration.md#引用文档配置
 sidebar:
   collapsed: false
+editRepoBaseUrl: alauda/doom/tree/main/docs

--- a/fixture-docs/doom.config.yml
+++ b/fixture-docs/doom.config.yml
@@ -45,3 +45,4 @@ releaseNotes:
 internalRoutes:
   - '*/internal/*.mdx'
   - '*/concepts/**'
+editRepoBaseUrl: alauda/doom/tree/main/fixture-docs

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -43,3 +43,8 @@ export function escapeMarkdownHeadingIds(content: string): string {
       .replace('\\\\{#', '\\{#'),
   )
 }
+
+export const defaultGitHubUrl = (url: string) =>
+  /^https?:\/\//.test(url)
+    ? url
+    : `https://github.com/${url.replace(/^(\/*github.com)?\/+/i, '')}`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import { type FSWatcher, watch } from 'chokidar'
 import { type Command, program } from 'commander'
 import { green } from 'yoctocolors'
 
+import { FALSY_VALUES, TRUTHY_VALUES } from '../shared/index.js'
 import type { GlobalCliOptions, ServeOptions } from '../types.js'
 import { setNodeEnv } from '../utils/index.js'
 
@@ -93,6 +94,13 @@ program
     '-r, --redirect <enum>',
     'Whether to redirect to the locale closest to `navigator.language` when the user visits the site, could be `auto`, `never` or `only-default-lang`',
     'only-default-lang',
+  )
+  .option(
+    '-R, --edit-repo [boolean|url]',
+    'Whether to enable or override the `editRepoBaseUrl` config feature, `https://github.com/` prefix could be omitted',
+    (value: string) =>
+      FALSY_VALUES.has(value) ? false : TRUTHY_VALUES.has(value) || value,
+    false,
   )
   .option(
     '-n, --no-open [boolean]',

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -221,7 +221,7 @@ export const newCommand = new Command('new')
       const target = path.resolve(render(layout.target, { parameters }))
       const when = layout.when && render(layout.when, { parameters })
 
-      if (JS_STR_FALSY_VALUES.has(when!)) {
+      if (JS_STR_FALSY_VALUES.has(when)) {
         continue
       }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,8 +1,22 @@
 export const ACP_BASE = '/container_platform/'
 
-export const FALSY_VALUES = new Set(['', '0', 'false', 'no', 'off', 'n', 'f'])
+export const FALSY_VALUES = new Set([
+  null,
+  undefined,
+  '',
+  '0',
+  'false',
+  'no',
+  'off',
+  'n',
+  'f',
+])
+
+export const TRUTHY_VALUES = new Set(['1', 'true', 'yes', 'on', 'y', 't'])
 
 export const JS_STR_FALSY_VALUES = new Set([
+  null,
+  undefined,
   '',
   '0',
   'false',

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,8 @@ export interface GlobalCliOptions {
   include?: string[]
   exclude?: string[]
   outDir?: string
-  redirect?: 'auto' | 'never'
+  redirect?: 'auto' | 'never' | 'only-default-lang'
+  editRepo?: boolean | string
 }
 
 export interface TranslateOptions {
@@ -49,6 +50,7 @@ declare module '@rspress/shared' {
     internalRoutes?: string[]
     translate?: TranslateOptions
     shiki?: PluginShikiOptions
+    editRepoBaseUrl?: string
   }
 }
 


### PR DESCRIPTION
close IDP-1166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an `editRepoBaseUrl` configuration option, allowing users to specify a base URL for editing documentation in their repository.
  - Introduced a new CLI flag `-R, --edit-repo [boolean|url]` to enable or override the edit repository feature.
  - Documentation and configuration files updated to describe and support the new edit link functionality.

- **Documentation**
  - Added sections explaining the new `editRepoBaseUrl` option and CLI flag.
  - Provided localized edit link text for multiple languages.

- **Chores**
  - Updated workflow to accommodate new CLI flag during documentation build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->