### PR TITLE
feat: enable cspell `allowCompoundWords` option

### DIFF
--- a/.changeset/nine-needles-jog.md
+++ b/.changeset/nine-needles-jog.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+feat: enable cspell `allowCompoundWords` option

--- a/doom.config.yml
+++ b/doom.config.yml
@@ -24,7 +24,4 @@ lint:
   cspellOptions:
     cspell:
       words:
-        - artifactcleanupruns
         - katanomi
-        - testplans
-        - testmodules

--- a/fixture-docs/doom.config.yml
+++ b/fixture-docs/doom.config.yml
@@ -50,8 +50,6 @@ lint:
   cspellOptions:
     cspell:
       words:
-        - gatewayview
-        - netrelationship
         - openshiftpipelinesascodes
         - tekton
         - tektonchains

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -48,6 +48,7 @@ export const lintCommand = new Command('lint')
                 {
                   autoFix: true,
                   cspell: {
+                    allowCompoundWords: true,
                     words: parsedTerms.map((it) => it.en),
                     flagWords: parsedTerms.flatMap(
                       ({ badCases }) => badCases?.en ?? [],


### PR DESCRIPTION
related https://github.com/streetsidesoftware/cspell/issues/6735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled support for compound words in spell checking, allowing them to be recognized as valid during linting.

- **Chores**
  - Updated spell checker configuration by removing several custom words from the allowed word lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->