### PR TITLE
feat: add `onlyIncludeRoutes` config support

### DIFF
--- a/.changeset/fresh-zoos-sip.md
+++ b/.changeset/fresh-zoos-sip.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+chore: enable `temperature: 0` for openai output stability

--- a/.changeset/young-snails-join.md
+++ b/.changeset/young-snails-join.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+feat: add `onlyIncludeRoutes` config support

--- a/docs/en/usage/configuration.md
+++ b/docs/en/usage/configuration.md
@@ -1,7 +1,7 @@
 ---
 description: Configure `doom` documentation tool
 weight: 1
-sourceSHA: e06d0647311a571bc2a3584ed125b83d6f6ab016738b27879f59aa32984fdd92
+sourceSHA: 11ecf257d004e931c672a3eeda41c811f327c91c61fba6625cbb858736213033
 ---
 
 # Configuration {#configuration}
@@ -20,7 +20,7 @@ export default defineConfig({})
 
 ## Basic Configuration {#basic}
 
-- `lang`: The default document language. For the convenience of the majority of projects, we support both Chinese and English documents by default, with the default language set to `en`. If the current document project does not require multilingual support, this can be set to `null` or `undefined`.
+- `lang`: The default document language. To accommodate most projects, we support both Chinese and English documents by default, with the default language set to `en`. If the current document project does not require multilingual support, this can be set to `null` or `undefined`.
 - `title`: The document title, which will appear in the browser tab.
 - `logo`: The logo in the top left corner of the document. It supports image links and file paths; absolute paths reference files in the `public` directory, while relative paths refer to files relative to the current tool directory. By default, it uses the built-in Alauda logo from the `doom` package.
 - `logoText`: The document title that will display at the logo location in the top left corner.
@@ -94,7 +94,7 @@ For writing documentation, refer to [reference documentation](./reference).
 ```yaml
 releaseNotes:
   queryTemplates:
-    fixed: # may include jql statements with ejs templates.
+    fixed: # May include jql statements with ejs templates.
     unfixed:
 ```
 
@@ -115,20 +115,29 @@ sidebar:
   collapsed: false # Optional, whether to default the left navigation to be collapsed. Defaults to collapsed. If there is not much document content, it can be set to false.
 ```
 
-## Internal Document Routes {#internal-routes}
+## Internal Document Routes Configuration {#internal-routes}
 
 ```yaml
 internalRoutes: # Optional, supports glob matching, relative to the docs directory. Matched files will be ignored if the cli is enabled with the `-i, --ignore` option.
   - '*/internal/**/*'
 ```
 
+## Only Include Document Routes Configuration {#only-include-routes}
+
+```yaml
+onlyIncludeRoutes: # Optional, supports glob matching, relative to the docs directory. Only routes/files under this configuration will be activated when the cli is enabled with the `-i, --ignore` option. Can be used in conjunction with `internalRoutes` to further exclude some routes within.
+  - '*/internal/**/*'
+internalRoutes:
+  - '*/internal/overview.mdx'
+```
+
 ## Language Highlight Plugin Configuration {#highlight}
 
 ```yaml
 shiki:
-  theme: # optional, https://shiki.style/themes
-  langs: # optional, https://shiki.style/languages
-  transformers: # optional, only available in js/ts config, https://shiki.style/guide/transformers
+  theme: # Optional, https://shiki.style/themes
+  langs: # Optional, https://shiki.style/languages
+  transformers: # Optional, only available in js/ts config, https://shiki.style/guide/transformers
 ```
 
 :::warning

--- a/docs/zh/usage/configuration.md
+++ b/docs/zh/usage/configuration.md
@@ -114,11 +114,20 @@ sidebar:
   collapsed: false # 可选，是否默认折叠左导航，默认折叠，文档内容不多时可以考虑设置为 false
 ```
 
-## 内部文档路由 \{#internal-routes}
+## 内部文档路由配置 \{#internal-routes}
 
 ```yaml
-internalRoutes: # 可选，支持 glob 匹配，相对于 docs 目录，匹配到的文件在 cli 启用 `-i, --ignore` 选项时会被忽略
-  - '*/internal/**/*'
+internalRoutes: # 可选，支持 glob 匹配，相对于 docs 目录，在 cli 启用 `-i, --ignore` 选项时匹配到的路由/文件会被忽略
+  - '*/internal/**'
+```
+
+## 仅包含文档路由配置 \{#only-include-routes}
+
+```yaml
+onlyIncludeRoutes: # 可选，支持 glob 匹配，相对于 docs 目录，在 cli 启用 `-i, --ignore` 选项时只有此配置下的路由/文件会被启用，可同时配合 `internalRoutes` 进一步排除其中的部分路由
+  - '*/internal/**'
+internalRoutes:
+  - '*/internal/overview.mdx'
 ```
 
 ## 语言高亮插件配置 \{#highlight}

--- a/fixture-docs/doom.config.yml
+++ b/fixture-docs/doom.config.yml
@@ -42,7 +42,10 @@ releaseNotes:
       AND ReleaseNotesStatus = Publish
       AND project = <%= project %>
     unfixed: ''
+onlyIncludeRoutes:
+  - '*/install/**'
 internalRoutes:
+  - '*/install/prerequisites.mdx'
   - '*/internal/*.mdx'
   - '*/concepts/**'
 editRepoBaseUrl: alauda/doom/tree/main/fixture-docs

--- a/src/cli/load-config.ts
+++ b/src/cli/load-config.ts
@@ -211,6 +211,7 @@ const getCommonConfig = async ({
     lang: fallbackToZh ? 'zh' : config.lang || 'en',
     title: '',
     route: {
+      include: ignore ? config.onlyIncludeRoutes : undefined,
       exclude: [
         'dist/**/*',
         'public/**/*',
@@ -218,6 +219,7 @@ const getCommonConfig = async ({
         'doom.config.*',
         '**/assets/**/*',
         '**/*.d.ts',
+        ...((ignore && config.internalRoutes) || []),
         ...unusedLanguages.map((lang) => `${lang}/**/*`),
       ],
     },

--- a/src/cli/translate.ts
+++ b/src/cli/translate.ts
@@ -167,6 +167,7 @@ export const translate = async ({
       },
     ],
     model: 'gpt-4o-mini',
+    temperature: 0,
   })
 
   const { content, refusal } = choices[0].message

--- a/src/plugins/auto-sidebar/index.ts
+++ b/src/plugins/auto-sidebar/index.ts
@@ -168,6 +168,7 @@ function processLocales(
   defaultLang: string,
   defaultVersion: string,
   extensions: string[],
+  onlyIncludeRoutes?: string[],
   excludeRoutes?: string[],
   collapsed?: boolean,
 ) {
@@ -186,6 +187,7 @@ function processLocales(
                 routePrefix,
                 root,
                 extensions,
+                onlyIncludeRoutes,
                 excludeRoutes,
                 collapsed,
               )
@@ -197,6 +199,7 @@ function processLocales(
               addTrailingSlash(lang === defaultLang ? '' : `/${lang}`),
               root,
               extensions,
+              onlyIncludeRoutes,
               excludeRoutes,
               collapsed,
             ),
@@ -218,6 +221,7 @@ export const autoSidebar = async (
   config: UserConfig,
   { ignore, export: export_ }: AutoSidebarPluginOptions,
 ) => {
+  const onlyIncludeRoutes = (ignore && config.onlyIncludeRoutes) || []
   const excludeRoutes = (ignore && config.internalRoutes) || []
   const route = (config.route ??= {})
   if (export_ || excludeRoutes.length) {
@@ -246,6 +250,7 @@ export const autoSidebar = async (
       defaultLang,
       defaultVersion,
       extensions,
+      onlyIncludeRoutes,
       excludeRoutes,
       collapsed,
     )
@@ -267,12 +272,23 @@ export const autoSidebar = async (
               routePrefix,
               config.root!,
               extensions,
+              onlyIncludeRoutes,
               excludeRoutes,
               collapsed,
             )
           }),
         )
-      : [await walk(root, '/', root, extensions, excludeRoutes, collapsed)]
+      : [
+          await walk(
+            root,
+            '/',
+            root,
+            extensions,
+            onlyIncludeRoutes,
+            excludeRoutes,
+            collapsed,
+          ),
+        ]
 
     const combined = combineWalkResult(walks, versions)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ declare module '@rspress/shared' {
     reference?: ReferenceItem[]
     sidebar?: Omit<AutoSidebarPluginOptions, 'download' | 'excludeRoutes'>
     releaseNotes?: ReleaseNotesOptions
+    onlyIncludeRoutes?: string[]
     internalRoutes?: string[]
     translate?: TranslateOptions
     shiki?: PluginShikiOptions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for a new configuration option to selectively include specific documentation routes when using the CLI ignore option, enabling more granular control over which routes are included or excluded.
  - Set OpenAI translation output temperature to zero for more consistent results.

- **Documentation**
  - Updated English and Chinese documentation to explain the new configuration option and provide improved examples and clarifications for route inclusion and exclusion settings.

- **Chores**
  - Updated example configuration files to demonstrate usage of the new selective route inclusion feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->