### PR TITLE
fix: exclude index pages correctly

### DIFF
--- a/.changeset/thick-panthers-juggle.md
+++ b/.changeset/thick-panthers-juggle.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+fix: exclude index pages correctly

--- a/fixture-docs/doom.config.yml
+++ b/fixture-docs/doom.config.yml
@@ -43,7 +43,7 @@ releaseNotes:
       AND project = <%= project %>
     unfixed: ''
 onlyIncludeRoutes:
-  - '*/install/**'
+  - '*/development/component-quickstart/*'
 internalRoutes:
   - '*/install/prerequisites.mdx'
   - '*/internal/*.mdx'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the logic to ensure index pages are properly excluded from the sidebar when matching exclusion rules.

- **Chores**
  - Updated configuration to focus on routes under "development/component-quickstart" instead of "install".
  - Added documentation for the patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->