### PR TITLE
fix: add zh locale support for algolia search

### DIFF
--- a/.changeset/healthy-shirts-wink.md
+++ b/.changeset/healthy-shirts-wink.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+fix: add zh locale support for algolia search

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,6 +2,7 @@ export const ACP_BASE = '/container_platform/'
 
 export const FALSY_VALUES = new Set([
   null,
+  undefined,
   '',
   '0',
   'false',

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,19 +1,32 @@
+import { useLang } from '@rspress/core/runtime'
 import { Search as OriginalSearch } from '@rspress/core/theme'
-import { Search as AlgoliaSearch } from '@rspress/plugin-algolia/runtime'
+import {
+  Search as AlgoliaSearch,
+  ZH_LOCALES,
+} from '@rspress/plugin-algolia/runtime'
+import { useMemo } from 'react'
 
 const Search =
   process.env.ALGOLIA_APP_ID &&
   process.env.ALGOLIA_API_KEY &&
   process.env.ALGOLIA_INDEX_NAME
-    ? () => (
-        <AlgoliaSearch
-          docSearchProps={{
+    ? () => {
+        const lang = useLang()
+        const docSearchProps = useMemo(
+          () => ({
             appId: process.env.ALGOLIA_APP_ID!,
             apiKey: process.env.ALGOLIA_API_KEY!,
             indexName: process.env.ALGOLIA_INDEX_NAME!,
-          }}
-        />
-      )
+            searchParameters: {
+              facetFilters: [`language:${lang}`],
+            },
+          }),
+          [lang],
+        )
+        return (
+          <AlgoliaSearch docSearchProps={docSearchProps} locales={ZH_LOCALES} />
+        )
+      }
     : OriginalSearch
 
 // eslint-disable-next-line import-x/export


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Chinese (zh) locale in the search functionality, allowing users to search and view results in Chinese.

- **Bug Fixes**
  - Improved search filtering to better handle language-specific results based on the user's current language.

- **Refactor**
  - Enhanced the search component to dynamically adapt to the selected language and optimize performance.

- **Chores**
  - Expanded the set of recognized falsy values to include undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->