### PR TITLE
feat: support algolia alauda preset

### DIFF
--- a/.changeset/major-cameras-rule.md
+++ b/.changeset/major-cameras-rule.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": minor
+---
+
+feat: support algolia alauda preset

--- a/docs/en/start.mdx
+++ b/docs/en/start.mdx
@@ -101,7 +101,7 @@ Options:
   -o, --out-dir <path>            Override the `outDir` defined in the config file or the default `dist/{base}/{version}`, the resulting path will be `dist/{outDir}/{version}`
   -r, --redirect <enum>           Whether to redirect to the locale closest to `navigator.language` when the user visits the site, could be `auto`, `never` or `only-default-lang` (default: "only-default-lang")
   -R, --edit-repo [boolean|url]   Whether to enable or override the `editRepoBaseUrl` config feature, `https://github.com/` prefix could be omitted (default: false)
-  -a, --algolia                   Whether to enable Algolia search (default: false)
+  -a, --algolia [boolean|alauda]  Whether to enable or use the alauda (docs.alauda.io) preset for Algolia search (default: false)
   -S, --site-url                  Whether to enable the siteUrl for sitemap generation (default: false)
   -n, --no-open [boolean]         Do not open the browser after starting the server
   -h, --help                      display help for command

--- a/docs/zh/start.mdx
+++ b/docs/zh/start.mdx
@@ -97,7 +97,7 @@ Options:
   -o, --out-dir <path>            Override the `outDir` defined in the config file or the default `dist/{base}/{version}`, the resulting path will be `dist/{outDir}/{version}`
   -r, --redirect <enum>           Whether to redirect to the locale closest to `navigator.language` when the user visits the site, could be `auto`, `never` or `only-default-lang` (default: "only-default-lang")
   -R, --edit-repo [boolean|url]   Whether to enable or override the `editRepoBaseUrl` config feature, `https://github.com/` prefix could be omitted (default: false)
-  -a, --algolia                   Whether to enable Algolia search (default: false)
+  -a, --algolia [boolean|alauda]  Whether to enable or use the alauda (docs.alauda.io) preset for Algolia search (default: false)
   -S, --site-url                  Whether to enable the siteUrl for sitemap generation (default: false)
   -n, --no-open [boolean]         Do not open the browser after starting the server
   -h, --help                      display help for command

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -4,11 +4,15 @@ import { glob } from 'tinyglobby'
 import { xfetch } from 'x-fetch'
 import { parse } from 'yaml'
 
-import { FALSY_VALUES } from '../shared/index.js'
+import { FALSY_VALUES, TRUTHY_VALUES } from '../shared/index.js'
 import type { NormalizedTermItem } from '../terms.js'
 
 export const parseBoolean = (value?: string) =>
   value === undefined || !FALSY_VALUES.has(value)
+
+export const parseBooleanOrString = (value?: string) =>
+  value === undefined ||
+  (FALSY_VALUES.has(value) ? false : TRUTHY_VALUES.has(value) || value)
 
 const DOC_PATTERN = /\.mdx?$/
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,13 +13,12 @@ import { type FSWatcher, watch } from 'chokidar'
 import { type Command, program } from 'commander'
 import { green } from 'yoctocolors'
 
-import { FALSY_VALUES, TRUTHY_VALUES } from '../shared/index.js'
 import type { GlobalCliOptions, ServeOptions } from '../types.js'
 import { setNodeEnv } from '../utils/index.js'
 
 import { CWD, DEFAULT_CONFIGS, I18N_FILE, SITES_FILE } from './constants.js'
 import { exportCommand } from './export.js'
-import { parseBoolean } from './helpers.js'
+import { parseBoolean, parseBooleanOrString } from './helpers.js'
 import { lintCommand } from './lint.js'
 import { loadConfig } from './load-config.js'
 import { newCommand } from './new.js'
@@ -99,15 +98,13 @@ program
   .option(
     '-R, --edit-repo [boolean|url]',
     'Whether to enable or override the `editRepoBaseUrl` config feature, `https://github.com/` prefix could be omitted',
-    (value?: string) =>
-      value === undefined ||
-      (FALSY_VALUES.has(value) ? false : TRUTHY_VALUES.has(value) || value),
+    parseBooleanOrString,
     false,
   )
   .option(
-    '-a, --algolia',
-    'Whether to enable Algolia search',
-    parseBoolean,
+    '-a, --algolia [boolean|alauda]',
+    'Whether to enable or use the alauda (docs.alauda.io) preset for Algolia search',
+    parseBooleanOrString,
     false,
   )
   .option(

--- a/src/cli/load-config.ts
+++ b/src/cli/load-config.ts
@@ -132,7 +132,7 @@ const getCommonConfig = async ({
   exclude?: string[]
   redirect?: 'auto' | 'never' | 'only-default-lang'
   editRepo?: boolean | string
-  algolia?: boolean
+  algolia?: boolean | 'alauda'
   siteUrl?: boolean
 }): Promise<UserConfig> => {
   const fallbackToZh = 'lang' in config && !config.lang
@@ -209,7 +209,14 @@ const getCommonConfig = async ({
 
   const { editLink, ...zhLocale } = KNOWN_LOCALE_CONFIGS.zh!
 
-  const algoliaOptions = algolia ? config.algolia : undefined
+  const algoliaOptions =
+    ((algolia && config.algolia) ??
+      (algolia === 'alauda' && {
+        appId: 'XN35Q5JLSV',
+        apiKey: '487fb969bdcda09dd4950468d7d8b61e',
+        indexName: 'docs_alauda_io_xn35q5jlsv_pages',
+      })) ||
+    null
 
   return {
     userBase,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface GlobalCliOptions {
   outDir?: string
   redirect?: 'auto' | 'never' | 'only-default-lang'
   editRepo?: boolean | string
-  algolia?: boolean
+  algolia?: boolean | 'alauda'
   siteUrl?: boolean
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The command-line option for enabling Algolia search now accepts a special "alauda" preset, allowing for quick configuration of search for the Alauda documentation site.
- **Documentation**
  - Updated both English and Chinese documentation to clarify the new usage of the `--algolia` option, including support for the "alauda" preset.
- **Chores**
  - Added metadata for a new minor version release supporting the Algolia Alauda preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->