### PR TITLE
feat: support export single entry as PDF

### DIFF
--- a/.changeset/spicy-glasses-own.md
+++ b/.changeset/spicy-glasses-own.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": minor
+---
+
+feat: support export single entry as PDF

--- a/docs/en/start.mdx
+++ b/docs/en/start.mdx
@@ -1,5 +1,5 @@
 ---
-sourceSHA: e8aa2b84d58ff17ca57bc7aa4aa8c4479944ae37b389df87676d487ab1ababe9
+sourceSHA: 66020a9ebd1f1f108b82b1bf05e1e8b3e51c7b35cb482a48a6e26a2c0bb74316
 ---
 
 # Getting Started \{#start}
@@ -12,7 +12,7 @@ First, you can create a new directory with the following command:
 mkdir my-docs && cd my-docs
 ```
 
-Run `npm init -y` to initialize a project. You can use npm, yarn, or pnpm to install doom:
+Run `npm init -y` to initialize a project. You can install doom using npm, yarn, or pnpm:
 
 <PackageManagerTabs command="install -D @alauda/doom typescript" />
 
@@ -24,7 +24,7 @@ mkdir docs/en && echo '# Hello World' > docs/en/index.md
 mkdir docs/zh && echo '# 你好世界' > docs/zh/index.md
 ```
 
-Add the following scripts to `package.json`:
+Add the following scripts to your `package.json`:
 
 ```json
 {
@@ -45,7 +45,7 @@ Then initialize a configuration file `doom.config.yml`:
 title: My Docs
 ```
 
-Also create `tsconfig.json` with the following content:
+Also create a `tsconfig.json` file with the following content:
 
 ```jsonc
 {
@@ -121,7 +121,7 @@ For more configuration, please refer to [Configuration](./usage/configuration)
 
 ### Starting the Development Server \{#dev}
 
-Run `yarn dev` to start the development server; the browser will automatically open the documentation homepage.
+Run `yarn dev` to start the development server, the browser will automatically open the documentation homepage.
 
 ```sh
 doom dev -h
@@ -148,11 +148,11 @@ Run `yarn build` to build the production code. After building, static files will
 
 ### Local Preview \{#serve}
 
-Run `yarn serve` to preview the built static files. Note that if you used `-b`, `-p` parameters during build, you need to use the same `-b`, `-p` parameters during preview.
+Run `yarn serve` to preview the built static files. Note that if you used `-b`, `-p` parameters during build, you also need to use `-b`, `-p` parameters during preview.
 
 ### Using Scaffolding Templates \{#new}
 
-Run `yarn new` to generate projects, modules, or documentation from scaffolding templates.
+Run `yarn new` to generate projects, modules, or documentation using scaffolding templates.
 
 ### Translating Documentation \{#translate}
 
@@ -175,24 +175,24 @@ Options:
   -h, --help               display help for command
 ```
 
-- The `-g, --glob` parameter is required and specifies the directories or files to translate, supporting `glob` syntax. Note that the parameter value must be quoted to avoid unexpected behavior from the shell. Examples:
+- The `-g, --glob` parameter is required and can specify the directories or paths of files to translate, supporting `glob` syntax. Note that the parameter value must be quoted, otherwise it may be parsed unexpectedly by the command line. Examples:
   1. `yarn translate -g abc xyz` will translate all documents under `<root>/<source>/abc` and `<root>/<source>/xyz` to `<root>/<target>/abc` and `<root>/<target>/xyz` respectively.
   2. `yarn translate -g '*'` will translate all documents under `<root>/<source>`.
-- The `-C, --copy` parameter is optional and controls whether to copy local asset files to the target directory when the target file does not exist. The default is `false`, which changes the asset reference paths to the source paths. Examples:
+- The `-C, --copy` parameter is optional. It determines whether to copy local asset files to the target directory when the target file does not exist. The default is `false`, which means changing the asset file reference path to the source path. Examples:
   - When enabled:
-    1. `/<source>/abc.jpg` will copy `<root>/public/<source>/abc.jpg` to `<root>/public/<target>/abc.jpg` and update the document reference path to `/<target>/abc.jpg`.
-    2. In `<root>/<source>/abc.mdx`, a reference to `./assets/xyz.jpg` will copy `<root>/<source>/assets/xyz.jpg` to `<root>/<target>/assets/xyz.jpg`, keeping the image reference path unchanged.
-    3. In `<root>/<source>/abc.mdx`, a reference to `./assets/<source>/xyz.jpg` will copy `<root>/<source>/assets/<source>/xyz.jpg` to `<root>/<target>/assets/<target>/xyz.jpg` and update the document reference path to `./assets/<target>/xyz.jpg`.
+    1. When translating `/<source>/abc.jpg`, it will copy `<root>/public/<source>/abc.jpg` to `<root>/public/<target>/abc.jpg` and update the document reference path to `/<target>/abc.jpg`.
+    2. In `<root>/<source>/abc.mdx`, if the document references `./assets/xyz.jpg`, it will copy `<root>/<source>/assets/xyz.jpg` to `<root>/<target>/assets/xyz.jpg`, and the image reference path remains unchanged.
+    3. In `<root>/<source>/abc.mdx`, if the document references `./assets/<source>/xyz.jpg`, it will copy `<root>/<source>/assets/<source>/xyz.jpg` to `<root>/<target>/assets/<target>/xyz.jpg` and update the document reference path to `./assets/<target>/xyz.jpg`.
   - When not enabled:
-    1. For `/<source>/abc.jpg`, if `<root>/public/<target>/abc.jpg` exists, the document reference path will be updated to `/<target>/abc.jpg`; otherwise, the image reference path remains unchanged.
-    2. In `<root>/<source>/abc.mdx`, if `<root>/<target>/assets/<target>/xyz.jpg` exists, the reference path will be updated to `./assets/<target>/xyz.jpg`; otherwise, it will be changed to `../<source>/assets/<target>/xyz.jpg`.
+    1. When translating `/<source>/abc.jpg`, if `<root>/public/<target>/abc.jpg` exists, the document reference path will be updated to `/<target>/abc.jpg`; otherwise, the image reference path remains unchanged.
+    2. In `<root>/<source>/abc.mdx`, if the document references `./assets/<source>/xyz.jpg`, and `<root>/<target>/assets/<target>/xyz.jpg` exists, the reference path will be updated to `./assets/<target>/xyz.jpg`; otherwise, it will be changed to `../<source>/assets/<target>/xyz.jpg`.
 
 :::warning
-Specifically, if you use `-g '*'` for full translation, the file lists of `source` and `target` directories will be compared, and unmatched `target` files except for `internalRoutes` will be automatically deleted.
+Specially, if you use `-g '*'` for full translation, the file lists of `source` and `target` directories will be compared, and unmatched `target` files except for `internalRoutes` will be automatically deleted.
 :::
 
 :::tip
-The translation feature requires the local environment variable `AZURE_OPENAI_API_KEY` to be configured. Please contact your team leader to obtain it.
+The translation feature requires the local environment variable `AZURE_OPENAI_API_KEY` to be configured. Please contact your team Leader to obtain it.
 :::
 
 You can control translation behavior in the document metadata:
@@ -231,13 +231,17 @@ Options:
   -h, --help         display help for command
 ```
 
-Run `yarn export` to export the documentation as PDF files. Note that if you used `-b`, `-p` parameters during build, you need to use the same `-b`, `-p` parameters during export.
+Run `yarn export` to export the documentation as a PDF file. Note that if you used `-b`, `-p` parameters during build, you also need to use `-b`, `-p` parameters during export.
 
-The export feature depends on [`playwright`](https://playwright.dev). For CI pipelines, please use `build-harbor.alauda.cn/frontend/playwright-runner:doom` as the base image for dependency installation and documentation building. Locally, you can set the following environment variable to speed up downloads:
+The export feature depends on [`playwright`](https://playwright.dev). For CI pipelines, please use `build-harbor.alauda.cn/frontend/playwright-runner:doom` as the base image for dependency installation and documentation building.
+
+Locally, you can set the following environment variable to speed up downloads:
 
 ```dotenv title=".env.yarn"
 PLAYWRIGHT_DOWNLOAD_HOST="https://cdn.npmmirror.com/binaries/playwright"
 ```
+
+For more configuration, please refer to [Documentation Export Configuration](./usage/configuration#export)
 
 ### Documentation Linting \{#lint}
 
@@ -272,11 +276,11 @@ Options:
   export { default } from '@alauda/doom/cspell'
   ```
 
-We also agree that the `.cspell` folder under the current working directory (`CWD`) is used to store CSpell dictionary files. For example, you can create `.cspell/k8s.txt`:
+We also conventionally use the `.cspell` folder in the current working directory (`CWD`) to store CSpell dictionary files. For example, you can create `.cspell/k8s.txt`:
 
 ```txt
 k8s
 kubernetes
 ```
 
-For more configuration, please refer to [Lint Configuration](./usage/configuration#lint)
+For more configuration, please refer to [Documentation Linting Configuration](./usage/configuration#lint)

--- a/docs/en/usage/configuration.md
+++ b/docs/en/usage/configuration.md
@@ -1,14 +1,14 @@
 ---
 description: Configure the `doom` documentation tool
 weight: 1
-sourceSHA: 1734866675471d4fc77ad60454f7672d8ef01c8f719d75b8c152d40886bc07e6
+sourceSHA: 7c6dee3aaeb330ff7c45ee0bc20d2c88de5d04cdcf910877d9bb3bb6c7d9a4b4
 ---
 
 # Configuration {#configuration}
 
 ## Configuration File {#config-file}
 
-In most cases, we only need to use a static `yaml` configuration file, supporting `doom.config.yaml` or `doom.config.yml`. For complex scenarios, such as requiring dynamic configuration or custom `rspress` plugins, `js/ts` configuration files can be used, supporting multiple file formats including `.js/.ts/.mjs/.mts/.cjs/.cts`.
+In most cases, a static `yaml` configuration file is sufficient. Both `doom.config.yaml` and `doom.config.yml` are supported. For more complex scenarios, such as requiring dynamic configuration or custom `rspress` plugins, `js/ts` configuration files can be used, supporting multiple file formats including `.js/.ts/.mjs/.mts/.cjs/.cts`.
 
 For `js/ts` configuration files, we need to export the configuration. You can use the `defineConfig` function exported from `@alauda/doom/config` to enable type assistance:
 
@@ -20,25 +20,25 @@ export default defineConfig({})
 
 ## Basic Configuration {#basic}
 
-- `lang`: Default document language. To accommodate most projects, we support both Chinese and English documents by default. The default language is `en`. If the current documentation project does not require multilingual support, this can be set to `null` or `undefined`.
-- `title`: Document title, displayed on the browser tab.
-- `logo`: Logo at the top left of the document, supports image URLs or file paths. Absolute paths refer to files under the `public` directory, relative paths refer to files relative to the current tool directory. The default is the Alauda logo built into the `doom` package.
-- `logoText`: Document title, displayed next to the logo at the top left.
-- `icon`: Document favicon, defaults to the same as `logo`.
-- `base`: Base path of the document, used when deploying to a non-root path, e.g., `product-docs`. Defaults to `/`.
-- `outDir`: Build output directory, defaults to `dist/{base}/{version}`. If specified, it changes to `dist/{outDir}/{version}`, where `version` is optional. See [Multi-version Build](./deploy#多版本构建) for reference.
+- `lang`: Default documentation language. To accommodate most projects, we support both Chinese and English documents by default. The default language is `en`. If the current documentation project does not require multilingual support, this can be set to `null` or `undefined`.
+- `title`: Documentation title, displayed on the browser tab.
+- `logo`: Logo at the top left of the documentation. Supports image URLs or file paths. Absolute paths refer to files under the `public` directory; relative paths refer to files relative to the current tool directory. Defaults to the Alauda logo built into the `doom` package.
+- `logoText`: Documentation title displayed next to the logo at the top left.
+- `icon`: Documentation favicon, defaults to the same as `logo`.
+- `base`: Base path of the documentation, used when deploying to a non-root path, e.g., `product-docs`. Defaults to `/`.
+- `outDir`: Output directory for build artifacts. Defaults to `dist/{base}/{version}`. If specified, it changes to `dist/{outDir}/{version}`, where `version` is optional. See [Multi-version Build](./deploy#多版本构建) for reference.
 
 ## API Documentation Configuration {#api}
 
 ```yaml
 api:
-  # CRD definition file paths, relative to the directory where doom.config.* is located, supports glob patterns, json/yaml files
+  # CRD definition file paths, relative to the directory where doom.config.* is located, supports glob matching, json/yaml files
   crds:
     - docs/shared/crds/*.yaml
-  # OpenAPI definition file paths, relative to the directory where doom.config.* is located, supports glob patterns, json/yaml files
+  # OpenAPI definition file paths, relative to the directory where doom.config.* is located, supports glob matching, json/yaml files
   openapis:
     - docs/shared/openapis/*.json
-  # When rendering OpenAPI related resource definitions, they are inlined by default. To extract related resource definitions into separate files, configure the following options.
+  # When rendering OpenAPI-related resource definitions, they are inlined by default. To extract related resource definitions into separate files, configure the following options.
   # Reference https://doom.alauda.cn/apis/references/CodeQuality.html#v1alpha1.CodeQualitySpec
   references:
     v1alpha1.CodeQualityBranch: /apis/references/CodeQualityBranch#v1alpha1.CodeQualityBranch
@@ -51,7 +51,7 @@ Refer to [API Documentation](./api) for writing documentation.
 ## Permission Documentation Configuration {#permission}
 
 ```yaml
-# The following resource file paths are relative to the directory where doom.config.* is located, support glob patterns, json/yaml files
+# The following resource file paths are relative to the directory where doom.config.* is located, support glob matching, json/yaml files
 permission:
   functionresources:
     # `kubectl get functionresources`
@@ -71,20 +71,20 @@ reference:
     branch: # [string] Optional, branch of the referenced documentation repository
     publicBase: # [string] Optional, when using a remote repository, the absolute path where static resources corresponding to /images/xx.png are located. Defaults to docs/public
     sources:
-      - name: anchor # Name of the referenced document, used for referencing in documentation, globally unique
-        path: docs/index.mdx#介绍 # Path of the referenced document, supports anchor positioning. For remote repositories, relative to the repository root; for local, relative to doom.config.* directory
+      - name: anchor # Reference documentation name, used for referencing in documents, globally unique
+        path: docs/index.mdx#介绍 # Reference document path, supports anchor positioning. For remote repositories, relative to the repository root; for local, relative to doom.config.* directory.
         ignoreHeading: # [boolean] Optional, whether to ignore the heading. If true, the anchor heading will not be displayed in the referenced document.
         processors: # Optional, processors for referenced document content
           - type: ejsTemplate
             data: # ejs template parameters, accessed via `<%= data.xx %>`
-        frontmatterMode: merge # Optional, mode for handling frontmatter of referenced documents. Defaults to ignore. Options: ignore/merge/replace/remove
+        frontmatterMode: merge # Optional, frontmatter processing mode for referenced documents. Defaults to ignore. Options: ignore/merge/replace/remove
 ```
 
 ### `frontmatterMode`
 
 - `ignore`: Ignore the frontmatter of the referenced document, keep using the current document's frontmatter.
-- `merge`: Merge the frontmatter of the referenced document. If keys conflict, the referenced document's values override the current document's.
-- `replace`: Replace the current document's frontmatter with that of the referenced document.
+- `merge`: Merge the frontmatter of the referenced document. If keys overlap, the referenced document's values override the current document's.
+- `replace`: Replace the current document's frontmatter with the referenced document's frontmatter.
 - `remove`: Remove the current document's frontmatter.
 
 Refer to [Reference Documentation](./reference#reference) for writing documentation.
@@ -106,26 +106,26 @@ releaseNotes:
 {/* release-notes-for-bugs?template=fixed&project=DevOps */}
 ```
 
-Taking `template=fixed&project=DevOps` as an example, `fixed` is the template name defined in `queryTemplates`. The remaining `query` parameter `project=DevOps` is passed as [`ejs`](https://github.com/mde/ejs) template parameters to the `fixed` template, which after processing is used as a jira [`jql`](https://www.atlassian.com/zh/software/jira/guides/jql/overview#what-is-jql) to initiate a request to `https://jira.alauda.cn/rest/api/2/search?jql=<jql>`. This API requires authentication, and the environment variables `JIRA_USERNAME` and `JIRA_PASSWORD` must be provided to preview successfully.
+Taking `template=fixed&project=DevOps` as an example, `fixed` is the template name defined in `queryTemplates`. The remaining `query` parameter `project=DevOps` is passed as [`ejs`](https://github.com/mde/ejs) template parameters to the `fixed` template, which processes it and sends a jira [`jql`](https://www.atlassian.com/zh/software/jira/guides/jql/overview#what-is-jql) request to `https://jira.alauda.cn/rest/api/2/search?jql=<jql>`. This API requires authentication, and `JIRA_USERNAME` and `JIRA_PASSWORD` environment variables must be provided for preview to take effect.
 
 ## Sidebar Configuration {#sidebar}
 
 ```yaml
 sidebar:
-  collapsed: false # Optional, whether to collapse the sidebar by default. Defaults to collapsed. When document content is small, consider setting to false.
+  collapsed: false # Optional, whether the sidebar is collapsed by default. Defaults to collapsed. When documentation content is small, consider setting to false.
 ```
 
-## Internal Document Routes Configuration {#internal-routes}
+## Internal Documentation Routes Configuration {#internal-routes}
 
 ```yaml
-internalRoutes: # Optional, supports glob patterns, relative to the docs directory. Routes/files matched when CLI option `-i, --ignore` is enabled will be ignored.
+internalRoutes: # Optional, supports glob matching, relative to the docs directory. Routes/files matched when the CLI option `-i, --ignore` is enabled will be ignored.
   - '*/internal/**'
 ```
 
-## Only Include Document Routes Configuration {#only-include-routes}
+## Only Include Routes Configuration {#only-include-routes}
 
 ```yaml
-onlyIncludeRoutes: # Optional, supports glob patterns, relative to the docs directory. When CLI option `-i, --ignore` is enabled, only routes/files under this configuration will be enabled. Can be combined with `internalRoutes` to further exclude some routes.
+onlyIncludeRoutes: # Optional, supports glob matching, relative to the docs directory. When the CLI option `-i, --ignore` is enabled, only routes/files under this configuration will be enabled. Can be used with `internalRoutes` to further exclude some routes.
   - '*/internal/**'
 internalRoutes:
   - '*/internal/overview.mdx'
@@ -141,7 +141,7 @@ shiki:
 ```
 
 :::warning
-Unconfigured languages will trigger warnings in the command line and fallback to `plaintext` rendering.
+Unconfigured languages will trigger a warning in the command line and fall back to `plaintext` rendering.
 :::
 
 ## `sites.yaml` Configuration {#sites}
@@ -149,7 +149,7 @@ Unconfigured languages will trigger warnings in the command line and fallback to
 The `sites.yaml` configuration file is used to configure subsite information associated with the current documentation site. This information is used by [External Site Components](./mdx#externalsite) and when building single-version documentation.
 
 ```yaml
-- name: connectors # Unique name across the entire site
+- name: connectors # Globally unique name
   base: /devops-connectors # Base path for site access
   version: v1.1 # Version used for ExternalSite/ExternalSiteLink redirection when building multi-version sites
 
@@ -158,8 +158,8 @@ The `sites.yaml` configuration file is used to configure subsite information ass
     zh: DevOps 连接器
 
   # The following properties are used to pull images when building the entire site. If not filled, this will be ignored during final packaging.
-  # Usually required for subsite references, not required for parent site references.
-  repo: https://github.com/AlaudaDevops/connectors-operator # Site repository address. For internal gitlab repositories, related slugs like `alauda/product-docs` can be used directly.
+  # Usually required for subsite references, not needed for parent site references.
+  repo: https://github.com/AlaudaDevops/connectors-operator # Site repository address. For internal GitLab repositories, related slugs like `alauda/product-docs` can be used directly.
   image: devops/connectors-docs # Site build image, used to pull images when building the entire site.
 ```
 
@@ -167,12 +167,12 @@ The `sites.yaml` configuration file is used to configure subsite information ass
 
 ```yaml
 translate:
-  # System prompt, ejs template, parameters passed include `sourceLang`, `targetLang`, `userPrompt`, `additionalPrompts`, `terms`, `titleTranslationPrompt`
-  # Where `sourceLang` and `targetLang` are the strings `中文` and `英文`,
-  #     `userPrompt` is the global user configuration below, may be empty
-  #     `additionalPrompts` is the `additionalPrompts` configuration in document `frontmatter.i18n`, may be empty
-  #     `terms` and `titleTranslationPrompt` are prompts dynamically generated based on terminology and title included in the document, used to guide AI translation according to terminology and title glossaries, may be empty
-  # The default system prompt is as follows and can be modified according to actual needs
+  # System prompt, ejs template. Parameters passed in include `sourceLang`, `targetLang`, `userPrompt`, `additionalPrompts`, `terms`, `titleTranslationPrompt`.
+  # `sourceLang` and `targetLang` are the strings `中文` and `英文`.
+  # `userPrompt` is the global user configuration below, may be empty.
+  # `additionalPrompts` is the `additionalPrompts` configuration in the document's `frontmatter.i18n`, may be empty.
+  # `terms` and `titleTranslationPrompt` are prompts dynamically generated based on terminology and title tables contained in the document content, used to guide AI translation according to terminology and title glossaries, may be empty.
+  # The default system prompt is as follows and can be modified according to actual needs.
   systemPrompt: |
 You are a professional technical documentation engineer, skilled in writing high-quality technical documentation in <%= targetLang %>. Please accurately translate the following text from <%= sourceLang %> to <%= targetLang %>, maintaining the style consistent with technical documentation in <%= sourceLang %>.
 
@@ -232,10 +232,20 @@ The text for translation is provided below, within triple quotes:
 ## Editing Documentation in Code Repository {#edit-repo}
 
 ```yaml
-editRepoBaseUrl: alauda/doom/tree/main/docs # The https://github.com/ prefix can be omitted. Effective only when the CLI flag `-R, --edit-repo` is enabled.
+editRepoBaseUrl: alauda/doom/tree/main/docs # The https://github.com/ prefix can be omitted. Only effective when the `-R, --edit-repo` CLI flag is enabled.
 ```
 
-## Documentation Linting Configuration {#lint}
+## Documentation Export Configuration {#export}
+
+In addition to exporting a complete PDF document for the entire site, `doom` also supports exporting a single PDF file for a specified entry. Configuration is as follows:
+
+```yaml
+export:
+  - name: Concepts # Optional, globally unique PDF name, defaults to the document title
+    entry: '*/concepts/index.mdx' # Required, string or array, document entry, supports glob matching, relative to the directory where doom config file is located
+```
+
+## Documentation Lint Configuration {#lint}
 
 ```yaml
 lint:
@@ -245,17 +255,17 @@ lint:
 ## Algolia Search Configuration {#algolia}
 
 ```yaml
-algolia: # Optional, Algolia search configuration, effective only when the CLI flag `-a, --algolia` is enabled
-  appId: # Algolia Application ID
+algolia: # Optional, Algolia search configuration, only effective when the `-a, --algolia` CLI flag is enabled
+  appId: # Algolia application ID
   apiKey: # Algolia API Key
   indexName: # Algolia index name
 ```
 
 Please use `public/robots.txt` for Algolia crawler verification.
 
-:::info
+::: info
 
-Due to current architectural limitations of `rspress`, using Algolia search requires implementing via [custom themes](https://rspress.dev/zh/guide/advanced/custom-theme). To unify usage of related theme features, we provide the `@alauda/doom/theme` theme entry. Please add the following theme configuration file to enable:
+Due to current architectural limitations of `rspress`, Algolia search functionality must be implemented through [custom themes](https://rspress.dev/zh/guide/advanced/custom-theme). To unify the use of related theme features, we provide the `@alauda/doom/theme` theme entry. Please add the following theme configuration file to enable it:
 
 ```ts title "theme/index.ts"
 export * from '@alauda/doom/theme'
@@ -266,5 +276,5 @@ export * from '@alauda/doom/theme'
 ## Sitemap Configuration {#sitemap}
 
 ```yaml
-siteUrl: https://docs.alauda.cn # Optional, site URL used for generating sitemap, effective only when the CLI flag `-S, --site-url` is enabled
+siteUrl: https://docs.alauda.cn # Optional, site URL used for generating sitemap, only effective when the `-S, --site-url` CLI flag is enabled
 ```

--- a/docs/zh/start.mdx
+++ b/docs/zh/start.mdx
@@ -237,6 +237,8 @@ Options:
 PLAYWRIGHT_DOWNLOAD_HOST="https://cdn.npmmirror.com/binaries/playwright"
 ```
 
+更多配置请参考[文档导出配置](./usage/configuration#export)
+
 ### 文档检查 \{#lint}
 
 ```sh

--- a/docs/zh/usage/configuration.md
+++ b/docs/zh/usage/configuration.md
@@ -234,6 +234,16 @@ The text for translation is provided below, within triple quotes:
 editRepoBaseUrl: alauda/doom/tree/main/docs # https://github.com/ 前缀可以省略，仅当启用 `-R, --edit-repo` 命令行标志符时生效
 ```
 
+## 文档导出配置 {#export}
+
+除了全站统一导出完整 pdf 文档外，`doom` 还支持指定入口导出单个 pdf 文件，配置如下：
+
+```yaml
+export:
+  - name: Concepts # 可选，全局唯一 pdf 名称，默认为文档标题
+    entry: '*/concepts/index.mdx' # 必填，字符串或数组，文档入口，支持 glob 匹配，相对于 doom 配置文件所在目录
+```
+
 ## 文档检查配置 {#lint}
 
 ```yaml

--- a/fixture-docs/doom.config.yml
+++ b/fixture-docs/doom.config.yml
@@ -6,6 +6,11 @@ api:
     - shared/crds/*.yaml
   openapis:
     - shared/openapis/*.json
+export:
+  - name: Concepts
+    entry: '*/concepts/index.mdx'
+  - name: Concepts Parameter
+    entry: '*/concepts/parameter/index.mdx'
 reference:
   - sources:
       - name: other

--- a/src/cli/export-pdf-core/generatePdf.ts
+++ b/src/cli/export-pdf-core/generatePdf.ts
@@ -27,6 +27,8 @@ export interface GeneratePdfOptions {
   host: string
   outFile: string
   outDir: string
+  cleanupTempDir?: boolean
+  allOutlines?: PDFOutline[]
   launchOptions?: LaunchOptions
   pdfOptions?: PDFOptions
   pdfOutlines?: boolean
@@ -44,6 +46,8 @@ export async function generatePdf({
   host,
   outFile,
   outDir,
+  cleanupTempDir = true,
+  allOutlines = [],
   urlOrigin,
   pdfOptions,
   pdfOutlines = true,
@@ -77,64 +81,70 @@ export async function generatePdf({
     }
   })
 
-  const singleBar = createProgress()
-  singleBar.start(normalizePages.length)
-
-  const printer = new Printer(printerOptions)
-
-  const page = await printer.setup(launchOptions)
-
-  if (urlOrigin && isValidUrlOrigin) {
-    await page.route('**/*', (route) => {
-      const reqUrl = route.request().url()
-      if (!isValidUrl(reqUrl)) {
-        return route.continue()
-      }
-      // http or https
-      const parsedUrl = new URL(reqUrl)
-      if (userURLOrigin === parsedUrl.origin) {
-        parsedUrl.host = host
-        parsedUrl.protocol = 'http:'
-        parsedUrl.port = `${port}`
-        const parsedUrlString = parsedUrl.toString()
-        return route.continue({
-          url: parsedUrlString,
-          headers: Object.assign({}, route.request().headers(), {
-            refer: parsedUrlString,
-            // Same origin
-            // origin: parsedUrl.origin,
-            // CORS
-            // host: parsedUrl.host,
-          }),
-        })
-      }
+  if (allOutlines.length) {
+    const allOutlinesMapping = new Map(allOutlines)
+    allOutlines = normalizePages.map(({ location }) => {
+      const { link } = getUrlLink(location)
+      return [link, allOutlinesMapping.get(link)!]
     })
-  }
+  } else {
+    const singleBar = createProgress()
+    singleBar.start(normalizePages.length)
 
-  const allOutlines: PDFOutline[] = []
+    const printer = new Printer(printerOptions)
 
-  for (const { location, pagePath, title } of normalizePages) {
-    const { data, outlineNodes } = await printer.pdf(
-      location,
-      {
-        format: 'A4',
-        ...pdfOptions,
-      },
-      pdfOutlines,
-    )
+    const page = await printer.setup(launchOptions)
 
-    if (pdfOutlines) {
-      allOutlines.push([getUrlLink(location).link, outlineNodes])
+    if (urlOrigin && isValidUrlOrigin) {
+      await page.route('**/*', (route) => {
+        const reqUrl = route.request().url()
+        if (!isValidUrl(reqUrl)) {
+          return route.continue()
+        }
+        // http or https
+        const parsedUrl = new URL(reqUrl)
+        if (userURLOrigin === parsedUrl.origin) {
+          parsedUrl.host = host
+          parsedUrl.protocol = 'http:'
+          parsedUrl.port = `${port}`
+          const parsedUrlString = parsedUrl.toString()
+          return route.continue({
+            url: parsedUrlString,
+            headers: Object.assign({}, route.request().headers(), {
+              refer: parsedUrlString,
+              // Same origin
+              // origin: parsedUrl.origin,
+              // CORS
+              // host: parsedUrl.host,
+            }),
+          })
+        }
+      })
     }
 
-    await writeFileSafe(pagePath, data)
+    for (const { location, pagePath, title } of normalizePages) {
+      const { data, outlineNodes } = await printer.pdf(
+        location,
+        {
+          format: 'A4',
+          ...pdfOptions,
+        },
+        pdfOutlines,
+      )
 
-    singleBar.increment(1, { headTitle: title || (await page.title()) })
+      if (pdfOutlines) {
+        allOutlines.push([getUrlLink(location).link, outlineNodes])
+      }
+
+      await writeFileSafe(pagePath, data)
+
+      singleBar.increment(1, { headTitle: title || (await page.title()) })
+    }
+
+    singleBar.stop()
+
+    await printer.closeBrowser()
   }
-
-  singleBar.stop()
-
-  await printer.closeBrowser()
 
   const exportedPath = await mergePDF(
     normalizePages,
@@ -146,6 +156,9 @@ export async function generatePdf({
   const message = `Exported to ${yellow(exportedPath)}\n`
   process.stdout.write(message)
 
-  await fs.rm(tempDir, { force: true, recursive: true })
-  return exportedPath
+  if (cleanupTempDir) {
+    await fs.rm(tempDir, { force: true, recursive: true })
+  }
+
+  return { exportedPath, allOutlines }
 }

--- a/src/cli/export-pdf-core/utils/mergePDF.ts
+++ b/src/cli/export-pdf-core/utils/mergePDF.ts
@@ -1,6 +1,5 @@
-import { Buffer } from 'node:buffer'
 import fs from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import path from 'node:path'
 import process from 'node:process'
 
 import {
@@ -12,7 +11,6 @@ import {
   PDFString,
 } from 'pdf-lib'
 import PDFMerger from 'pdf-merger-js'
-import { red } from 'yoctocolors'
 
 import type { OutlineNode } from '../../html-export-pdf/index.js'
 import { mergePDFs } from '../../merge-pdfs/index.js'
@@ -176,21 +174,18 @@ export async function mergePDF(
   outDir: string,
   pdfOutlines: PDFOutline[],
 ) {
-  const saveDirPath = join(process.cwd(), outDir)
+  const saveDirPath = path.resolve(outDir)
 
   if (outDir) {
     await fs.mkdir(saveDirPath, { recursive: true })
   }
 
-  const saveFilePath = join(saveDirPath, outFile)
+  const saveFilePath = path.join(saveDirPath, outFile)
 
   if (pages.length === 0) {
-    process.stderr.write(
-      red(
-        'The website has no pages, please check whether the export path is set correctly',
-      ),
+    throw new Error(
+      'The website has no pages, please check whether the export path is set correctly',
     )
-    process.exit(1)
   } else if (pages.length === 1) {
     await fs.rename(pages[0].pagePath, saveFilePath)
   } else {
@@ -198,7 +193,7 @@ export async function mergePDF(
     if (pdfOutlines.length > 0) {
       pdfData = await mergePDFs(
         pages.map(({ pagePath }) => {
-          const relativePagePath = relative(process.cwd(), pagePath)
+          const relativePagePath = path.relative(process.cwd(), pagePath)
           return convertPathToPosix(relativePagePath)
         }),
       )
@@ -214,5 +209,5 @@ export async function mergePDF(
     await fs.writeFile(saveFilePath, pdfData)
   }
 
-  return relative(process.cwd(), saveFilePath)
+  return path.relative(process.cwd(), saveFilePath)
 }

--- a/src/cli/export.ts
+++ b/src/cli/export.ts
@@ -1,10 +1,17 @@
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import { removeLeadingSlash, serve } from '@rspress/core'
 import { logger } from '@rspress/shared/logger'
 import { Command } from 'commander'
+import { cyan, yellow } from 'yoctocolors'
 
-import { autoSidebar, type DoomSidebar } from '../plugins/index.js'
+import {
+  autoSidebar,
+  type DoomSidebar,
+  type DoomSidebarGroup,
+  type DoomSidebarItem,
+} from '../plugins/index.js'
 import { getPdfName } from '../shared/index.js'
 import type { GlobalCliOptions, ServeOptions } from '../types.js'
 import { pathExists, setNodeEnv } from '../utils/index.js'
@@ -13,8 +20,27 @@ import {
   generatePdf,
   type GeneratePdfOptions,
   type Page,
+  type PDFOutline,
 } from './export-pdf-core/index.js'
 import { loadConfig } from './load-config.js'
+
+const collectPages = (sidebarItems: DoomSidebar[], base: string) => {
+  const pages: Page[] = []
+  for (const item of sidebarItems) {
+    if ('link' in item && item.link) {
+      const link = removeLeadingSlash(item.link)
+      pages.push({
+        key: link,
+        path: base + link + '.html?print',
+        title: item.text,
+      })
+    }
+    if ('items' in item) {
+      pages.push(...collectPages(item.items, base))
+    }
+  }
+  return pages
+}
 
 export const exportCommand = new Command('export')
   .description(
@@ -56,26 +82,10 @@ export const exportCommand = new Command('export')
 
     await serve({ config, host, port })
 
-    const collectPages = (sidebarItems: DoomSidebar[]) => {
-      const pages: Page[] = []
-      for (const item of sidebarItems) {
-        if ('link' in item && item.link) {
-          const link = removeLeadingSlash(item.link)
-          pages.push({
-            key: link,
-            path: config.base! + link + '.html?print',
-            title: item.text,
-          })
-        }
-        if ('items' in item) {
-          pages.push(...collectPages(item.items))
-        }
-      }
-      return pages
-    }
+    const tempDir = path.resolve(outDir, '.doom')
 
     const commonOptions: Omit<GeneratePdfOptions, 'pages' | 'outFile'> = {
-      tempDir: path.resolve(outDir, '.doom'),
+      tempDir,
       port: port!,
       host: host || 'localhost',
       outDir,
@@ -112,16 +122,65 @@ export const exportCommand = new Command('export')
     const exportPdf = async (
       sidebarItems: DoomSidebar[],
       lang = config.lang!,
+      options?: Partial<GeneratePdfOptions>,
     ) => {
-      const pages = collectPages(sidebarItems)
-      logger.start(
-        `Exporting ${lang} language documents with ${pages.length} pages...`,
-      )
-      await generatePdf({
+      const pages = collectPages(sidebarItems, config.base!)
+      const pdfOptions = {
         pages,
         outFile: getPdfName(lang, config.userBase, config.title),
+        cleanupTempDir: false,
         ...commonOptions,
-      })
+        ...options,
+      }
+      logger.start(
+        `Exporting ${options ? 'custom' : 'all'} ${lang} language documents with ${pages.length} pages into ${yellow(pdfOptions.outFile)}...`,
+      )
+      return generatePdf(pdfOptions)
+    }
+
+    const findEntryFactory = (entry: string[]) =>
+      function findEntry(
+        sidebarItems: DoomSidebar[],
+      ): DoomSidebarGroup | DoomSidebarItem | undefined {
+        for (const item of sidebarItems) {
+          if (!('_fileKey' in item) || !item._fileKey) {
+            continue
+          }
+          if (entry.includes(item._fileKey)) {
+            return item
+          }
+          if ('items' in item) {
+            const found = findEntry(item.items)
+            if (found) {
+              return found
+            }
+          }
+        }
+      }
+
+    const exportItems = config.export || []
+
+    const exportEntries = async (
+      sidebarItems: DoomSidebar[],
+      allOutlines: PDFOutline[],
+      lang = config.lang!,
+    ) => {
+      for (const item of exportItems) {
+        // already normalized by `loadConfig`
+        const entry = item.entry as string[]
+        const findEntry = findEntryFactory(entry)
+        const found = findEntry(sidebarItems)
+        if (!found) {
+          logger.warn(
+            `Cannot find entry \`${cyan(entry.join(', '))}\` for lang ${lang}, skip exporting`,
+          )
+          continue
+        }
+        await exportPdf([found], lang, {
+          allOutlines,
+          outFile: `${item.name || found.text}-${lang}.pdf`,
+        })
+      }
     }
 
     if (themeConfig.locales?.length) {
@@ -129,12 +188,16 @@ export const exportCommand = new Command('export')
         const sidebarItems = sidebar![
           config.lang === lang ? '/' : `/${lang}`
         ] as DoomSidebar[]
-        await exportPdf(sidebarItems, lang)
+        const { allOutlines } = await exportPdf(sidebarItems, lang)
+        await exportEntries(sidebarItems, allOutlines, lang)
       }
     } else {
       const sidebarItems = themeConfig.sidebar!['/'] as DoomSidebar[]
-      await exportPdf(sidebarItems)
+      const { allOutlines } = await exportPdf(sidebarItems)
+      await exportEntries(sidebarItems, allOutlines)
     }
+
+    await fs.rm(tempDir, { force: true, recursive: true })
 
     logger.ready('Closing the server')
     process.exit(0)

--- a/src/cli/load-config.ts
+++ b/src/cli/load-config.ts
@@ -28,6 +28,7 @@ import {
   transformerRemoveNotationEscape,
 } from '@shikijs/transformers'
 import { difference } from 'es-toolkit'
+import { globSync } from 'tinyglobby'
 import { cyan } from 'yoctocolors'
 
 import {
@@ -350,6 +351,10 @@ const getCommonConfig = async ({
         },
       },
     },
+    export: config.export?.map((item) => ({
+      ...item,
+      entry: globSync(item.entry, { cwd: localBasePath }),
+    })),
   }
 }
 
@@ -475,6 +480,8 @@ export async function loadConfig(
     lang: commonConfig.lang,
     root: commonConfig.root,
   })
+
+  mergedConfig.export = commonConfig.export
 
   if (base && prefix) {
     mergedConfig.base = (mergedConfig.prefix = normalizeSlash(prefix)) + base

--- a/src/global/VersionsNav/index.tsx
+++ b/src/global/VersionsNav/index.tsx
@@ -3,8 +3,9 @@ import {
   NoSSR,
   removeTrailingSlash,
   usePageData,
+  withBase,
 } from '@rspress/core/runtime'
-import type { NavItem } from '@rspress/shared'
+import { type NavItem } from '@rspress/shared'
 import virtual from 'doom-@global-virtual'
 import { noop } from 'es-toolkit'
 import { useEffect, useMemo, useState } from 'react'
@@ -57,8 +58,8 @@ const VersionsNav_ = () => {
       return
     }
 
-    return siteData.base + getPdfName(lang, virtual.userBase, siteTitle)
-  }, [lang, siteData.base, siteTitle])
+    return withBase(getPdfName(lang, virtual.userBase, siteTitle))
+  }, [lang, siteTitle])
 
   const [versionsBase, version] = useMemo(() => {
     const unversionedVersion = getUnversionedVersion(virtual.version)

--- a/src/plugins/global/index.ts
+++ b/src/plugins/global/index.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { addTrailingSlash, type RspressPlugin } from '@rspress/core'
 
 import { ACP_BASE, type DoomSite } from '../../shared/index.js'
+import type { ExportItem } from '../../types.js'
 import { baseResolve, pkgResolve } from '../../utils/index.js'
 
 const globalComponentsDir = baseResolve('global')
@@ -18,6 +19,7 @@ export interface GlobalVirtual extends GlobalPluginOptions {
   userBase?: string
   prefix?: string
   sites?: DoomSite[]
+  export?: ExportItem[]
 }
 
 // @internal
@@ -65,6 +67,7 @@ export const globalPlugin = ({
               ),
               version: site.version,
             })),
+            export: config.export,
           },
           null,
           isProd ? 0 : 2,

--- a/src/runtime/translation.ts
+++ b/src/runtime/translation.ts
@@ -16,6 +16,7 @@ const en = {
   english_bad_cases: 'English Bad Cases',
   download_pdf: 'Download PDF',
   toc: 'TOC',
+  view_docs_as_pdf: 'View full docs as PDF',
 }
 
 export type Translation = typeof en
@@ -38,6 +39,7 @@ const zh: Translation = {
   english_bad_cases: '英文反例',
   download_pdf: '下载 PDF',
   toc: '目录',
+  view_docs_as_pdf: '以 PDF 格式查看完整文档',
 }
 
 const ru: Translation = {
@@ -58,6 +60,7 @@ const ru: Translation = {
   english_bad_cases: 'Примеры ошибок на английском',
   download_pdf: 'Скачать PDF',
   toc: 'Содержание',
+  view_docs_as_pdf: 'Просмотреть полную документацию в формате PDF',
 }
 
 export const TRANSLATIONS = { en, zh, ru }

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,12 +1,149 @@
-import { useLang } from '@rspress/core/runtime'
-import { Search as OriginalSearch } from '@rspress/core/theme'
+import { useLang, usePageData, withBase } from '@rspress/core/runtime'
+import {
+  Search as OriginalSearch,
+  Layout as OriginalLayout,
+  getCustomMDXComponent,
+} from '@rspress/core/theme'
 import {
   Search as AlgoliaSearch,
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime'
+import virtual from 'doom-@global-virtual'
 import { useMemo } from 'react'
+import { useLocation } from 'react-router'
 
-const Search =
+import classes from '../styles/link.module.scss'
+
+import type {
+  DoomSidebar,
+  DoomSidebarGroup,
+  DoomSidebarItem,
+} from './plugins/index.js'
+import { useTranslation } from './runtime/index.js'
+import type { ExportItem } from './types.js'
+
+// eslint-disable-next-line import-x/export
+export * from '@rspress/core/theme'
+
+const X = getCustomMDXComponent()
+
+export interface MatchedSidebar {
+  sidebar: DoomSidebarGroup | DoomSidebarItem
+  exportItem: ExportItem
+  depth: number
+}
+
+const getClosestSidebar_ = (
+  sidebarItems: DoomSidebar[],
+  pathname: string,
+  exportItem: ExportItem,
+  matched?: MatchedSidebar,
+  depth = 0,
+): MatchedSidebar | undefined => {
+  for (const sidebar of sidebarItems) {
+    if ('_fileKey' in sidebar && sidebar._fileKey) {
+      if (exportItem.entry.includes(sidebar._fileKey)) {
+        matched = {
+          sidebar,
+          exportItem,
+          depth,
+        }
+      }
+
+      if (
+        withBase(sidebar.link) ===
+        (pathname.endsWith('.html') ? pathname.slice(0, -5) : pathname)
+      ) {
+        return matched
+      }
+    }
+
+    if ('items' in sidebar) {
+      const found = getClosestSidebar_(
+        sidebar.items,
+        pathname,
+        exportItem,
+        matched,
+      )
+      if (found) {
+        return found
+      }
+    }
+  }
+}
+
+const getClosestSidebar = (sidebarItems: DoomSidebar[], pathname: string) => {
+  let found: MatchedSidebar | undefined
+  for (const item of virtual.export!) {
+    const matched = getClosestSidebar_(sidebarItems, pathname, item)
+    if (matched) {
+      if (!found || matched.depth >= found.depth) {
+        found = matched
+      }
+    }
+  }
+  return found
+}
+
+// eslint-disable-next-line import-x/export
+export const Layout = () => {
+  const {
+    siteData: { lang: siteLang, themeConfig },
+  } = usePageData()
+
+  const lang = useLang()
+
+  const t = useTranslation()
+
+  const { pathname } = useLocation()
+
+  const found = useMemo(() => {
+    if (!virtual.export?.length) {
+      return
+    }
+
+    if (themeConfig.locales?.length) {
+      for (const { lang, sidebar } of themeConfig.locales) {
+        const sidebarItems = sidebar![
+          siteLang === lang ? '/' : `/${lang}`
+        ] as DoomSidebar[]
+        return getClosestSidebar(sidebarItems, pathname)
+      }
+    } else {
+      const sidebarItems = themeConfig.sidebar!['/'] as DoomSidebar[]
+      return getClosestSidebar(sidebarItems, pathname)
+    }
+  }, [pathname, siteLang, themeConfig])
+
+  const pdfLink = useMemo(
+    () =>
+      found &&
+      withBase(`${found.exportItem.name ?? found.sidebar.text}-${lang}.pdf`),
+    [found, lang],
+  )
+
+  return (
+    <OriginalLayout
+      beforeOutline={
+        pdfLink && (
+          <X.p>
+            <a
+              className={classes.link}
+              href={pdfLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('view_docs_as_pdf')}
+            </a>
+          </X.p>
+        )
+      }
+    />
+  )
+}
+
+// eslint-disable-next-line import-x/export
+export const Search =
   process.env.ALGOLIA_APP_ID &&
   process.env.ALGOLIA_API_KEY &&
   process.env.ALGOLIA_INDEX_NAME
@@ -28,8 +165,3 @@ const Search =
         )
       }
     : OriginalSearch
-
-// eslint-disable-next-line import-x/export
-export * from '@rspress/core/theme'
-// eslint-disable-next-line import-x/export
-export { Search }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,13 @@ export interface AlgoliaOptions {
   indexName: string
 }
 
+export interface ExportItem {
+  name?: string
+  entry: string | string[]
+  onlyInclude?: string[]
+  exclude?: string[]
+}
+
 declare module '@rspress/shared' {
   interface UserConfig {
     prefix?: string
@@ -66,6 +73,7 @@ declare module '@rspress/shared' {
     lint?: LintOptions
     algolia?: AlgoliaOptions
     siteUrl?: string
+    export?: ExportItem[]
   }
 
   interface SiteData {


### PR DESCRIPTION
close IDP-1215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exporting individual documentation entries as separate PDF files, with configuration options for custom naming and entry selection.
  * UI now provides localized links to view specific documentation sections as PDF, with improved sidebar detection for context-aware PDF links.

* **Documentation**
  * Updated English and Chinese docs with new sections and examples explaining PDF export configuration.
  * Enhanced clarity, consistency, and detail across configuration and getting started guides.
  * Added references and examples for new export functionality.

* **Bug Fixes**
  * Improved PDF export process with better temporary file cleanup and error handling.

* **Refactor**
  * Streamlined PDF export logic and improved internal structure for easier maintenance and extension.

* **Style**
  * Minor formatting and capitalization improvements in documentation and UI text.

* **Tests**
  * Updated configuration fixtures to demonstrate new export capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->