### PR TITLE
fix: remove unnecessary lang part in external site link

### DIFF
--- a/.changeset/two-knives-flow.md
+++ b/.changeset/two-knives-flow.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+fix: remove unnecessary lang part in external site link

--- a/src/runtime/components/ExternalSiteLink.tsx
+++ b/src/runtime/components/ExternalSiteLink.tsx
@@ -1,4 +1,4 @@
-import { NoSSR, useLang } from '@rspress/core/runtime'
+import { NoSSR, useLang, usePageData } from '@rspress/core/runtime'
 import {
   addTrailingSlash,
   isExternalUrl,
@@ -31,6 +31,8 @@ const ExternalSiteLink_ = ({
 }: ExternalSiteLinkProps) => {
   const isPrint = useIsPrint()
 
+  const { siteData } = usePageData()
+
   const site = useMemo(
     () => virtual.sites?.find((s) => s.name === name),
     [name],
@@ -52,7 +54,7 @@ const ExternalSiteLink_ = ({
 
   let { url, hash } = parseUrl(href)
 
-  const extname = url.split('.').pop()
+  const extname = url.split('.').at(-1)
 
   if (extname) {
     if (DEFAULT_PAGE_EXTENSIONS.includes(`.${extname}`)) {
@@ -70,7 +72,7 @@ const ExternalSiteLink_ = ({
         (isUnversioned(virtual.version)
           ? site.base
           : addTrailingSlash(site.base + site.version)) +
-        (lang ? addTrailingSlash(lang) : '') +
+        (lang && lang !== siteData.lang ? addTrailingSlash(lang) : '') +
         (hash ? `${url}#${hash}` : url)
       }
       target="_blank"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external site link behavior by only appending the language segment when it differs from the current site language, preventing unnecessary language parts in URLs.

* **Chores**
  * Added a changeset file to document the patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->