### PR TITLE
fix: ignore `internalRoutes` when `--ignore` enabled

### DIFF
--- a/.changeset/late-bees-draw.md
+++ b/.changeset/late-bees-draw.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+fix: ignore `internalRoutes` when `--ignore` enabled

--- a/packages/doom/src/cli/lint.ts
+++ b/packages/doom/src/cli/lint.ts
@@ -36,6 +36,7 @@ export const lintCommand = new Command('lint')
     const eslint = new ESLint({
       cwd: docsDir,
       overrideConfigFile: true,
+      ignorePatterns: globalOptions.ignore ? config.internalRoutes : undefined,
       // @ts-expect-error -- stronger types
       overrideConfig: await doom(cspell ? config.lint?.cspellOptions : null),
     })


### PR DESCRIPTION
close IDP-1316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The lint command now correctly ignores internal routes when the --ignore flag is used, preventing unintended files from being linted.

* **Chores**
  * Added a changeset for a patch release of @alauda/doom documenting the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->