### PR TITLE
refactor: reconstruct types reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@ This monorepo contains the Doom documentation tool, export functionality, and re
 ## Commands
 
 - **Build**: `yarn build` (clean and compile TypeScript)
-- **Clean**: `yarn clean` (clean TypeScript build artifacts)
 - **Dev**: `yarn dev` (development mode with file watching)
 - **Docs**: `yarn docs` (build and export docs) | `yarn docs:build` | `yarn docs:export`
 - **Format**: `yarn format` (format code with Prettier)

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   ],
   "packageManager": "yarn@4.13.0",
   "scripts": {
-    "build": "yarn clean && tsc -b",
-    "clean": "tsc -b --clean",
+    "build": "tsc -b",
     "dev": "yarn swc-node --watch-path packages/doom/src/cli --watch-path packages/doom/src/plugins packages/doom/src/cli/index.ts",
     "docs": "run-s docs:build docs:export",
     "docs:build": "yarn doom build",

--- a/packages/doom/global.d.ts
+++ b/packages/doom/global.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="@total-typescript/ts-reset" />
-/// <reference types="@alauda/doom/types" />
 
 type MDXProvidedComponents = typeof import('@alauda/doom/runtime')
 

--- a/packages/doom/src/runtime/index.ts
+++ b/packages/doom/src/runtime/index.ts
@@ -2,6 +2,8 @@
 /// <reference path="../../shim.d.ts" />
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../global.d.ts" preserve="true" />
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../types.ts" preserve="true" />
 
 export * from '../terms.js'
 export * from './components/index.js'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified build process by removing the pre-build clean step and the separate clean command.
  * Adjusted how package type references are referenced/handled to streamline declarations.
* **Documentation**
  * Removed the now-obsolete clean command entry from the project documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->