### PR TITLE
test: improve unit test coverage for doom and export packages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,6 +51,12 @@ export default defineConfig(
     },
   },
   {
+    files: ['**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'off',
+    },
+  },
+  {
     files: ['**/*.mdx'],
     rules: {
       '@eslint-react/jsx-no-children-prop': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,7 +51,7 @@ export default defineConfig(
     },
   },
   {
-    files: ['**/*.{ts,tsx}'],
+    files: ['**/test/**/*.spec.{ts,tsx}'],
     rules: {
       '@typescript-eslint/no-floating-promises': 'off',
     },

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "release": "yarn build && changeset publish",
     "serve": "yarn doom serve",
     "swc-node": "node --enable-source-maps --import @swc-node/register/esm-register",
-    "test": "rstest run",
-    "test:watch": "rstest watch",
+    "test": "rstest --coverage",
     "translate": "yarn doom translate -g '*' -s zh -t en",
     "typecov": "type-coverage",
     "version": "changeset version && yarn --no-immutable"
@@ -37,6 +36,7 @@
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.30.0",
     "@rstest/core": "^0.9.6",
+    "@rstest/coverage-istanbul": "^0.3.1",
     "@swc-node/register": "^1.11.1",
     "@swc/core": "^1.15.24",
     "@types/cli-progress": "^3.11.6",

--- a/packages/doom/src/plugins/auto-sidebar/utils.ts
+++ b/packages/doom/src/plugins/auto-sidebar/utils.ts
@@ -86,11 +86,16 @@ export async function extractInfoFromFrontmatter(
   }
 }
 
-export function combineWalkResult(
-  walks: { nav: NavItem[]; sidebar: Record<string, DoomSidebar[]> }[],
-  versions: string[],
-) {
-  return walks.reduce(
+export interface WalkResult {
+  nav: NavItem[]
+  sidebar: Record<string, DoomSidebar[]>
+}
+
+export function combineWalkResult(walks: WalkResult[], versions: string[]) {
+  return walks.reduce<{
+    nav: Record<string, NavItem[]>
+    sidebar: Record<string, DoomSidebar[]>
+  }>(
     (acc, cur, curIndex) => ({
       nav: { ...acc.nav, [versions[curIndex] || 'default']: cur.nav },
       sidebar: { ...acc.sidebar, ...cur.sidebar },

--- a/packages/doom/src/plugins/replace/utils.ts
+++ b/packages/doom/src/plugins/replace/utils.ts
@@ -51,8 +51,8 @@ export const mdProcessor = unified()
 export const mdxProcessor = mdProcessor().use(remarkMdx).freeze()
 
 export const getFrontmatterNode = (ast: Root): Yaml | undefined => {
-  const firstNode = ast.children[0]
-  return firstNode.type === 'yaml' ? firstNode : undefined
+  const firstNode = ast.children.at(0)
+  return firstNode?.type === 'yaml' ? firstNode : undefined
 }
 
 const { CI } = process.env

--- a/packages/doom/src/utils/fs.ts
+++ b/packages/doom/src/utils/fs.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises'
+import fs from 'node:fs/promises'
 
 export async function pathExists(path: string, type?: 'file' | 'directory') {
   try {

--- a/packages/doom/test/cli/helpers.spec.ts
+++ b/packages/doom/test/cli/helpers.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from '@rstest/core'
+
+import {
+  defaultGitHubUrl,
+  escapeMarkdownHeadingIds,
+  isDoc,
+  parseBoolean,
+  parseBooleanOrString,
+} from '#cli/helpers.ts'
+
+describe('parseBoolean', () => {
+  test('returns true for undefined', () => {
+    expect(parseBoolean(undefined)).toBe(true)
+  })
+
+  test('returns false for "false"', () => {
+    expect(parseBoolean('false')).toBe(false)
+  })
+
+  test('returns false for "0"', () => {
+    expect(parseBoolean('0')).toBe(false)
+  })
+
+  test('returns false for "no"', () => {
+    expect(parseBoolean('no')).toBe(false)
+  })
+
+  test('returns false for "off"', () => {
+    expect(parseBoolean('off')).toBe(false)
+  })
+
+  test('returns false for "n"', () => {
+    expect(parseBoolean('n')).toBe(false)
+  })
+
+  test('returns false for "f"', () => {
+    expect(parseBoolean('f')).toBe(false)
+  })
+
+  test('returns true for "true"', () => {
+    expect(parseBoolean('true')).toBe(true)
+  })
+
+  test('returns true for "1"', () => {
+    expect(parseBoolean('1')).toBe(true)
+  })
+
+  test('returns true for arbitrary non-falsy string', () => {
+    expect(parseBoolean('anything')).toBe(true)
+  })
+})
+
+describe('parseBooleanOrString', () => {
+  test('returns true for undefined', () => {
+    expect(parseBooleanOrString(undefined)).toBe(true)
+  })
+
+  test('returns false for falsy values', () => {
+    expect(parseBooleanOrString('false')).toBe(false)
+    expect(parseBooleanOrString('0')).toBe(false)
+    expect(parseBooleanOrString('no')).toBe(false)
+  })
+
+  test('returns true for truthy values', () => {
+    expect(parseBooleanOrString('true')).toBe(true)
+    expect(parseBooleanOrString('1')).toBe(true)
+    expect(parseBooleanOrString('yes')).toBe(true)
+    expect(parseBooleanOrString('on')).toBe(true)
+    expect(parseBooleanOrString('y')).toBe(true)
+    expect(parseBooleanOrString('t')).toBe(true)
+  })
+
+  test('returns string value for non-boolean strings', () => {
+    expect(parseBooleanOrString('custom-value')).toBe('custom-value')
+    expect(parseBooleanOrString('path/to/file')).toBe('path/to/file')
+  })
+})
+
+describe('isDoc', () => {
+  test('returns true for .md files', () => {
+    expect(isDoc('file.md')).toBe(true)
+    expect(isDoc('path/to/file.md')).toBe(true)
+  })
+
+  test('returns true for .mdx files', () => {
+    expect(isDoc('file.mdx')).toBe(true)
+    expect(isDoc('path/to/file.mdx')).toBe(true)
+  })
+
+  test('returns false for non-doc files', () => {
+    expect(isDoc('file.ts')).toBe(false)
+    expect(isDoc('file.js')).toBe(false)
+    expect(isDoc('file.txt')).toBe(false)
+    expect(isDoc('file.json')).toBe(false)
+  })
+
+  test('returns false for files with md in the name but different extension', () => {
+    expect(isDoc('markdown.txt')).toBe(false)
+    expect(isDoc('mdx-file.js')).toBe(false)
+  })
+})
+
+describe('escapeMarkdownHeadingIds', () => {
+  test('escapes custom heading IDs', () => {
+    const input = '# Hello World {#custom-id}'
+    const expected = '# Hello World \\{#custom-id}'
+    expect(escapeMarkdownHeadingIds(input)).toBe(expected)
+  })
+
+  test('escapes multiple heading IDs', () => {
+    const input = '# First {#first-id}\n## Second {#second-id}'
+    const expected = '# First \\{#first-id}\n## Second \\{#second-id}'
+    expect(escapeMarkdownHeadingIds(input)).toBe(expected)
+  })
+
+  test('does not double escape already escaped IDs', () => {
+    const input = '# Hello \\{#already-escaped}'
+    const expected = '# Hello \\{#already-escaped}'
+    expect(escapeMarkdownHeadingIds(input)).toBe(expected)
+  })
+
+  test('preserves content without heading IDs', () => {
+    const input = '# Regular Heading\n\nSome content.'
+    expect(escapeMarkdownHeadingIds(input)).toBe(input)
+  })
+
+  test('handles all heading levels', () => {
+    const input =
+      '# H1 {#h1}\n## H2 {#h2}\n### H3 {#h3}\n#### H4 {#h4}\n##### H5 {#h5}\n###### H6 {#h6}'
+    const expected =
+      '# H1 \\{#h1}\n## H2 \\{#h2}\n### H3 \\{#h3}\n#### H4 \\{#h4}\n##### H5 \\{#h5}\n###### H6 \\{#h6}'
+    expect(escapeMarkdownHeadingIds(input)).toBe(expected)
+  })
+})
+
+describe('defaultGitHubUrl', () => {
+  test('returns url as-is if already has protocol', () => {
+    expect(defaultGitHubUrl('https://github.com/user/repo')).toBe(
+      'https://github.com/user/repo',
+    )
+    expect(defaultGitHubUrl('http://github.com/user/repo')).toBe(
+      'http://github.com/user/repo',
+    )
+  })
+
+  test('adds https://github.com/ prefix for short paths', () => {
+    expect(defaultGitHubUrl('user/repo')).toBe('https://github.com/user/repo')
+  })
+
+  test('handles leading slashes', () => {
+    expect(defaultGitHubUrl('/user/repo')).toBe('https://github.com/user/repo')
+    expect(defaultGitHubUrl('//user/repo')).toBe('https://github.com/user/repo')
+  })
+
+  test('handles github.com prefix without protocol', () => {
+    expect(defaultGitHubUrl('github.com/user/repo')).toBe(
+      'https://github.com/user/repo',
+    )
+    expect(defaultGitHubUrl('/github.com/user/repo')).toBe(
+      'https://github.com/user/repo',
+    )
+  })
+})

--- a/packages/doom/test/plugins/auto-sidebar/utils.spec.ts
+++ b/packages/doom/test/plugins/auto-sidebar/utils.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from '@rstest/core'
+
+import {
+  combineWalkResult,
+  type WalkResult,
+} from '#plugins/auto-sidebar/utils.ts'
+
+describe('combineWalkResult', () => {
+  test('combines single walk result with default version', () => {
+    const walks = [
+      {
+        nav: [{ text: 'Home', link: '/' }],
+        sidebar: { '/': [{ text: 'Intro', link: '/intro' }] },
+      },
+    ]
+    const versions: string[] = []
+
+    const result = combineWalkResult(walks, versions)
+
+    expect(result).toEqual({
+      nav: { default: [{ text: 'Home', link: '/' }] },
+      sidebar: { '/': [{ text: 'Intro', link: '/intro' }] },
+    })
+  })
+
+  test('combines multiple walk results with versions', () => {
+    const walks: WalkResult[] = [
+      {
+        nav: [{ text: 'Home v1', link: '/v1' }],
+        sidebar: { '/v1': [{ text: 'Intro v1', link: '/v1/intro' }] },
+      },
+      {
+        nav: [{ text: 'Home v2', link: '/v2' }],
+        sidebar: { '/v2': [{ text: 'Intro v2', link: '/v2/intro' }] },
+      },
+    ]
+    const versions = ['v1.0.0', 'v2.0.0']
+
+    const result = combineWalkResult(walks, versions)
+
+    expect(result).toEqual({
+      nav: {
+        'v1.0.0': [{ text: 'Home v1', link: '/v1' }],
+        'v2.0.0': [{ text: 'Home v2', link: '/v2' }],
+      },
+      sidebar: {
+        '/v1': [{ text: 'Intro v1', link: '/v1/intro' }],
+        '/v2': [{ text: 'Intro v2', link: '/v2/intro' }],
+      },
+    })
+  })
+
+  test('handles empty walks array', () => {
+    const walks: { nav: []; sidebar: Record<string, []> }[] = []
+    const versions: string[] = []
+
+    const result = combineWalkResult(walks, versions)
+
+    expect(result).toEqual({
+      nav: {},
+      sidebar: {},
+    })
+  })
+
+  test('merges sidebar entries from multiple walks', () => {
+    const walks: WalkResult[] = [
+      {
+        nav: [{ text: 'Nav1', link: '/nav1' }],
+        sidebar: {
+          '/docs': [{ text: 'Doc1', link: '/docs/1' }],
+        },
+      },
+      {
+        nav: [{ text: 'Nav2', link: '/nav2' }],
+        sidebar: {
+          '/api': [{ text: 'API1', link: '/api/1' }],
+        },
+      },
+    ]
+    const versions = ['latest', 'next']
+
+    const result = combineWalkResult(walks, versions)
+
+    expect(result.sidebar).toEqual({
+      '/docs': [{ text: 'Doc1', link: '/docs/1' }],
+      '/api': [{ text: 'API1', link: '/api/1' }],
+    })
+    expect(result.nav).toEqual({
+      latest: [{ text: 'Nav1', link: '/nav1' }],
+      next: [{ text: 'Nav2', link: '/nav2' }],
+    })
+  })
+
+  test('later walks override earlier sidebar entries with same key', () => {
+    const walks: WalkResult[] = [
+      {
+        nav: [{ text: 'Nav1', link: '/nav1' }],
+        sidebar: {
+          '/shared': [{ text: 'Old', link: '/shared/old' }],
+        },
+      },
+      {
+        nav: [{ text: 'Nav2', link: '/nav2' }],
+        sidebar: {
+          '/shared': [{ text: 'New', link: '/shared/new' }],
+        },
+      },
+    ]
+    const versions = ['v1', 'v2']
+
+    const result = combineWalkResult(walks, versions)
+
+    expect(result.sidebar['/shared']).toEqual([
+      { text: 'New', link: '/shared/new' },
+    ])
+  })
+})

--- a/packages/doom/test/plugins/auto-toc/remark-auto-toc.spec.ts
+++ b/packages/doom/test/plugins/auto-toc/remark-auto-toc.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from '@rstest/core'
+import type { Root } from 'mdast'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+import { remarkAutoToc } from '#plugins/auto-toc/remark-auto-toc.ts'
+
+const parser = unified().use(remarkParse)
+
+const parseAndTransform = (markdown: string): Root => {
+  const tree = parser.parse(markdown)
+  // @ts-expect-error - We know the plugin will modify the tree in place, but TypeScript doesn't understand that.
+  remarkAutoToc()(tree)
+  return tree
+}
+
+describe('remarkAutoToc', () => {
+  test('inserts Toc component before first h2', () => {
+    const markdown = '# Title\n\n## First Section\n\nContent'
+    const tree = parseAndTransform(markdown)
+
+    // Should have: h1, import, div(with Toc), h2, paragraph
+    const types = tree.children.map((child) => (child as { type: string }).type)
+    expect(types).toContain('mdxJsxFlowElement')
+  })
+
+  test('adds useTranslation import', () => {
+    const markdown = '## Section\n\nContent'
+    const tree = parseAndTransform(markdown)
+
+    const importNode = tree.children.find(
+      (child) => (child as { type: string }).type === 'mdxjsEsm',
+    )
+    expect(importNode).toBeDefined()
+  })
+
+  test('does not modify document without h2', () => {
+    const markdown = '# Title\n\n### H3 only\n\nContent'
+    const originalTree = parser.parse(markdown)
+    const transformedTree = parseAndTransform(markdown)
+
+    expect(transformedTree.children.length).toBe(originalTree.children.length)
+  })
+
+  test('creates div with doom-auto-toc class', () => {
+    const markdown = '## Section'
+    const tree = parseAndTransform(markdown)
+
+    const divElement = tree.children.find(
+      (child) =>
+        (child as { type: string; name?: string }).type ===
+          'mdxJsxFlowElement' &&
+        (child as { type: string; name: string }).name === 'div',
+    ) as unknown as {
+      attributes: Array<{ name: string; value: string }>
+    }
+
+    expect(divElement).toBeDefined()
+    const classAttr = divElement.attributes.find(
+      (attr) => attr.name === 'className',
+    )
+    expect(classAttr!.value).toContain('doom-auto-toc')
+  })
+
+  test('includes rp-toc-exclude class', () => {
+    const markdown = '## Section'
+    const tree = parseAndTransform(markdown)
+
+    const divElement = tree.children.find(
+      (child) =>
+        (child as { type: string; name?: string }).type ===
+          'mdxJsxFlowElement' &&
+        (child as { type: string; name: string }).name === 'div',
+    ) as unknown as {
+      attributes: Array<{ name: string; value: string }>
+    }
+
+    const classAttr = divElement.attributes.find(
+      (attr) => attr.name === 'className',
+    )
+    expect(classAttr!.value).toContain('rp-toc-exclude')
+  })
+
+  test('inserts before first h2, preserving content before', () => {
+    const markdown = '# Title\n\nSome paragraph\n\n## First H2\n\n## Second H2'
+    const tree = parseAndTransform(markdown)
+
+    // Find the position of the first h2
+    const h2Index = tree.children.findIndex(
+      (child) =>
+        (child as { type: string; depth?: number }).type === 'heading' &&
+        (child as { depth: number }).depth === 2,
+    )
+
+    // The import and div should be inserted before the first h2
+    // so h2Index should be after the import and div
+    expect(h2Index).toBeGreaterThan(1)
+  })
+
+  test('handles document starting with h2', () => {
+    const markdown = '## First Section\n\nContent'
+    const tree = parseAndTransform(markdown)
+
+    // Import should be first
+    expect((tree.children[0] as { type: string }).type).toBe('mdxjsEsm')
+    // Div with Toc should be second
+    expect((tree.children[1] as { type: string }).type).toBe(
+      'mdxJsxFlowElement',
+    )
+  })
+})

--- a/packages/doom/test/plugins/directives/remark-directives.spec.ts
+++ b/packages/doom/test/plugins/directives/remark-directives.spec.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from '@rstest/core'
+import type { Root } from 'mdast'
+import remarkDirective from 'remark-directive'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+import { remarkDirectives } from '#plugins/directives/remark-directives.ts'
+
+const parser = unified().use(remarkParse).use(remarkDirective)
+
+const parseAndTransform = (markdown: string): Root => {
+  const tree = parser.parse(markdown)
+  // @ts-expect-error - We know the plugin will modify the tree in place, but TypeScript doesn't understand that.
+  remarkDirectives()(tree)
+  return tree
+}
+
+describe('remarkDirectives', () => {
+  test('transforms callouts directive to div with doom-callouts class', () => {
+    const markdown = ':::callouts\nSome content\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      data: { hProperties: { className: string[] } }
+    }
+
+    expect(directive.data.hProperties.className).toContain('doom-callouts')
+  })
+
+  test('transforms callout directive to span with doom-callout class', () => {
+    const markdown = ':::callout\nContent\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      data: { hName: string; hProperties: { className: string[] } }
+    }
+
+    expect(directive.data.hName).toBe('span')
+    expect(directive.data.hProperties.className).toContain('doom-callout')
+  })
+
+  test('preserves standard container directives (tip)', () => {
+    const markdown = ':::tip\nTip content\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      type: string
+      name: string
+      data?: unknown
+    }
+
+    expect(directive.type).toBe('containerDirective')
+    expect(directive.name).toBe('tip')
+  })
+
+  test('preserves standard container directives (warning)', () => {
+    const markdown = ':::warning\nWarning content\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      type: string
+      name: string
+    }
+
+    expect(directive.type).toBe('containerDirective')
+    expect(directive.name).toBe('warning')
+  })
+
+  test('preserves standard container directives (danger)', () => {
+    const markdown = ':::danger\nDanger content\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      type: string
+      name: string
+    }
+
+    expect(directive.type).toBe('containerDirective')
+    expect(directive.name).toBe('danger')
+  })
+
+  test('preserves standard container directives (note)', () => {
+    const markdown = ':::note\nNote content\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      type: string
+      name: string
+    }
+
+    expect(directive.type).toBe('containerDirective')
+    expect(directive.name).toBe('note')
+  })
+
+  test('preserves standard container directives (caution)', () => {
+    const markdown = ':::caution\nCaution content\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      type: string
+      name: string
+    }
+
+    expect(directive.type).toBe('containerDirective')
+    expect(directive.name).toBe('caution')
+  })
+
+  test('preserves standard container directives (info)', () => {
+    const markdown = ':::info\nInfo content\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      type: string
+      name: string
+    }
+
+    expect(directive.type).toBe('containerDirective')
+    expect(directive.name).toBe('info')
+  })
+
+  test('preserves standard container directives (details)', () => {
+    const markdown = ':::details\nDetails content\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      type: string
+      name: string
+    }
+
+    expect(directive.type).toBe('containerDirective')
+    expect(directive.name).toBe('details')
+  })
+
+  test('preserves attributes on callouts directive', () => {
+    const markdown = ':::callouts{.custom-class #my-id}\nContent\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      data: { hProperties: { className: string[]; id?: string } }
+    }
+
+    expect(directive.data.hProperties.className).toContain('custom-class')
+    expect(directive.data.hProperties.className).toContain('doom-callouts')
+  })
+
+  test('handles multiple consecutive callouts directives', () => {
+    const markdown = ':::callouts\nFirst\n:::\n\n:::callouts\nSecond\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directives = tree.children.filter(
+      (child) =>
+        (child as { type: string }).type === 'containerDirective' &&
+        (child as { name: string }).name === 'callouts',
+    )
+
+    expect(directives).toHaveLength(2)
+    for (const directive of directives) {
+      const d = directive as unknown as {
+        data: { hProperties: { className: string[] } }
+      }
+      expect(d.data.hProperties.className).toContain('doom-callouts')
+    }
+  })
+
+  test('handles nested content in callout directive', () => {
+    const markdown =
+      ':::callout\n**Bold** and *italic* text\n\n- List item\n:::'
+    const tree = parseAndTransform(markdown)
+
+    const directive = tree.children[0] as unknown as {
+      data: { hName: string }
+      children: unknown[]
+    }
+
+    expect(directive.data.hName).toBe('span')
+    expect(directive.children.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/doom/test/plugins/mermaid/remark-mermaid.spec.ts
+++ b/packages/doom/test/plugins/mermaid/remark-mermaid.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from '@rstest/core'
+import type { Root } from 'mdast'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+import { remarkMermaid } from '#plugins/mermaid/remark-mermaid.ts'
+
+const parser = unified().use(remarkParse)
+
+const parseAndTransform = (markdown: string): Root => {
+  const tree = parser.parse(markdown)
+  // @ts-expect-error - We know the plugin will modify the tree in place, but TypeScript doesn't understand that.
+  remarkMermaid()(tree)
+  return tree
+}
+
+describe('remarkMermaid', () => {
+  test('transforms mermaid code block to Mermaid JSX element', () => {
+    const markdown = '```mermaid\ngraph TD\nA --> B\n```'
+    const tree = parseAndTransform(markdown)
+
+    const element = tree.children[0] as unknown as {
+      type: string
+      name: string
+      attributes: Array<{ name: string; value: string }>
+    }
+
+    expect(element.type).toBe('mdxJsxFlowElement')
+    expect(element.name).toBe('Mermaid')
+  })
+
+  test('passes mermaid content as children attribute', () => {
+    const markdown = '```mermaid\nsequenceDiagram\nAlice->>Bob: Hello\n```'
+    const tree = parseAndTransform(markdown)
+
+    const element = tree.children[0] as unknown as {
+      attributes: Array<{ name: string; value: string }>
+    }
+
+    const childrenAttr = element.attributes.find(
+      (attr) => attr.name === 'children',
+    )
+    expect(childrenAttr).toBeDefined()
+    expect(childrenAttr!.value).toBe('sequenceDiagram\nAlice->>Bob: Hello')
+  })
+
+  test('does not transform non-mermaid code blocks', () => {
+    const markdown = '```javascript\nconst x = 1;\n```'
+    const tree = parseAndTransform(markdown)
+
+    const element = tree.children[0] as unknown as { type: string }
+    expect(element.type).toBe('code')
+  })
+
+  test('preserves other content around mermaid blocks', () => {
+    const markdown = '# Title\n\n```mermaid\ngraph\n```\n\nText after'
+    const tree = parseAndTransform(markdown)
+
+    expect(tree.children).toHaveLength(3)
+    expect((tree.children[0] as unknown as { type: string }).type).toBe(
+      'heading',
+    )
+    expect((tree.children[1] as unknown as { type: string }).type).toBe(
+      'mdxJsxFlowElement',
+    )
+    expect((tree.children[2] as unknown as { type: string }).type).toBe(
+      'paragraph',
+    )
+  })
+
+  test('handles empty mermaid block', () => {
+    const markdown = '```mermaid\n```'
+    const tree = parseAndTransform(markdown)
+
+    const element = tree.children[0] as unknown as {
+      type: string
+      attributes: Array<{ name: string; value: string }>
+    }
+
+    expect(element.type).toBe('mdxJsxFlowElement')
+    const childrenAttr = element.attributes.find(
+      (attr) => attr.name === 'children',
+    )
+    expect(childrenAttr!.value).toBe('')
+  })
+
+  test('does not modify code block with different language', () => {
+    const markdown = '```typescript\nconst x: number = 1;\n```'
+    const tree = parseAndTransform(markdown)
+
+    const element = tree.children[0] as unknown as {
+      type: string
+      lang: string
+    }
+
+    expect(element.type).toBe('code')
+    expect(element.lang).toBe('typescript')
+  })
+
+  test('handles mermaid block with complex diagram', () => {
+    const markdown = `\`\`\`mermaid
+flowchart LR
+  A[Start] --> B{Decision}
+  B -->|Yes| C[OK]
+  B -->|No| D[Cancel]
+\`\`\``
+    const tree = parseAndTransform(markdown)
+
+    const element = tree.children[0] as unknown as {
+      type: string
+      name: string
+      attributes: Array<{ name: string; value: string }>
+    }
+
+    expect(element.type).toBe('mdxJsxFlowElement')
+    expect(element.name).toBe('Mermaid')
+
+    const childrenAttr = element.attributes.find(
+      (attr) => attr.name === 'children',
+    )
+    expect(childrenAttr!.value).toContain('flowchart LR')
+    expect(childrenAttr!.value).toContain('A[Start]')
+  })
+})

--- a/packages/doom/test/plugins/replace/rehype-normalize-link.spec.ts
+++ b/packages/doom/test/plugins/replace/rehype-normalize-link.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from '@rstest/core'
+import type { Element, Root } from 'hast'
+
+import { rehypeNormalizeLink } from '#plugins/replace/rehype-normalize-link.ts'
+
+const createImgElement = (
+  src: string | number | undefined,
+  alt?: string,
+): Element => ({
+  type: 'element',
+  tagName: 'img',
+  properties: { src, alt },
+  children: [],
+})
+
+const createTree = (children: Element[]): Root => ({
+  type: 'root',
+  children,
+})
+
+describe('rehypeNormalizeLink', () => {
+  const process = (tree: Root): Root => {
+    // @ts-expect-error - We are directly testing the plugin function
+    rehypeNormalizeLink()(tree)
+    return tree
+  }
+
+  describe('image handling', () => {
+    test('transforms relative image src to mdx import', () => {
+      const tree = createTree([createImgElement('./image.png', 'test')])
+      const result = process(tree)
+
+      // Should have added an import at the beginning
+      expect(result.children.length).toBe(2)
+
+      // First child should be mdxjsEsm import
+      const importNode = result.children[0]
+      expect(importNode.type).toBe('mdxjsEsm')
+    })
+
+    test('ignores external URLs', () => {
+      const tree = createTree([
+        createImgElement('https://example.com/image.png', 'external'),
+      ])
+      const originalLength = tree.children.length
+      const result = process(tree)
+
+      // Should not add imports for external URLs
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(0)
+      expect(result.children.length).toBe(originalLength)
+    })
+
+    test('ignores absolute paths', () => {
+      const tree = createTree([createImgElement('/images/logo.png', 'logo')])
+      const originalLength = tree.children.length
+      const result = process(tree)
+
+      // Should not add imports for absolute paths
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(0)
+      expect(result.children.length).toBe(originalLength)
+    })
+
+    test('handles img without src', () => {
+      const tree = createTree([createImgElement(undefined, 'no-src')])
+      const result = process(tree)
+
+      // Should not crash and should not add imports
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(0)
+    })
+
+    test('handles img with non-string src', () => {
+      const tree = createTree([createImgElement(123, 'test')])
+      const result = process(tree)
+
+      // Should not crash and should not add imports
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(0)
+    })
+
+    test('handles multiple images', () => {
+      const tree = createTree([
+        createImgElement('./a.png', 'a'),
+        createImgElement('./b.png', 'b'),
+        createImgElement('https://external.com/c.png', 'c'),
+      ])
+      const result = process(tree)
+
+      // Should add 2 imports (for a.png and b.png, not for external)
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(2)
+    })
+
+    test('ignores non-img elements', () => {
+      const tree = createTree([
+        {
+          type: 'element',
+          tagName: 'div',
+          properties: { src: './image.png' },
+          children: [],
+        },
+      ])
+      const result = process(tree)
+
+      // Should not add imports for non-img elements
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(0)
+    })
+
+    test('transforms img without alt attribute', () => {
+      const tree = createTree([createImgElement('./image.png')])
+      const result = process(tree)
+
+      // Should still transform the image
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(1)
+    })
+
+    test('transforms relative paths with parent directory', () => {
+      const tree = createTree([createImgElement('../assets/image.png', 'test')])
+      const result = process(tree)
+
+      // Should add import for relative path with ../
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(1)
+    })
+
+    test('transforms nested relative paths', () => {
+      const tree = createTree([
+        createImgElement('./deep/nested/image.png', 'test'),
+      ])
+      const result = process(tree)
+
+      // Should add import for nested relative path
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(1)
+    })
+
+    test('generates unique variable names for multiple images', () => {
+      const tree = createTree([
+        createImgElement('./first.png', 'first'),
+        createImgElement('./second.png', 'second'),
+      ])
+      const result = process(tree)
+
+      const imports = result.children.filter((c) => c.type === 'mdxjsEsm')
+      expect(imports.length).toBe(2)
+
+      // Check import values are unique
+      const importValues = imports.map((i) => (i as { value?: string }).value)
+      expect(new Set(importValues).size).toBe(2)
+    })
+
+    test('transforms img element to mdxJsxFlowElement', () => {
+      const tree = createTree([createImgElement('./image.png', 'test')])
+      process(tree)
+
+      // The img element should be transformed
+      const transformed = tree.children.find(
+        (c) => (c as { name?: string }).name === 'img',
+      )
+      expect(transformed).toBeDefined()
+      expect((transformed as { type: string }).type).toBe('mdxJsxFlowElement')
+    })
+  })
+})

--- a/packages/doom/test/plugins/replace/utils.spec.ts
+++ b/packages/doom/test/plugins/replace/utils.spec.ts
@@ -1,13 +1,15 @@
-import { describe, expect, test } from '@rstest/core'
+import { afterEach, describe, expect, rstest, test } from '@rstest/core'
 import type { Root } from 'mdast'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkParse from 'remark-parse'
 import { unified } from 'unified'
+import { red } from 'yoctocolors'
 
 import type { ReferenceItem } from '#plugins/replace/types.ts'
 import {
-  normalizeReferenceItems,
   getFrontmatterNode,
+  normalizeReferenceItems,
+  RELATIVE_URL_PATTERN,
 } from '#plugins/replace/utils.ts'
 
 const parser = unified().use(remarkParse).use(remarkFrontmatter, ['yaml'])
@@ -17,6 +19,12 @@ const parseMarkdownWithFrontmatter = (markdown: string): Root => {
 }
 
 describe('normalizeReferenceItems', () => {
+  const consoleError = console.error
+
+  afterEach(() => {
+    console.error = consoleError
+  })
+
   test('returns empty object for empty array', () => {
     const result = normalizeReferenceItems([])
 
@@ -142,10 +150,18 @@ describe('normalizeReferenceItems', () => {
       },
     ]
 
+    console.error = rstest.fn()
+
     const result = normalizeReferenceItems(items)
 
     expect(result['config'].path).toBe('/second.md')
     expect(result['config'].anchor).toBe('anchor')
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Duplicate source name \`${red('config')}\` will be deduplicated`,
+      ),
+    )
   })
 
   test('handles multiple items with different repos', () => {
@@ -206,5 +222,78 @@ describe('getFrontmatterNode', () => {
     expect(frontmatter).toBeDefined()
     expect(frontmatter?.type).toBe('yaml')
     expect(frontmatter?.value).toBeTruthy()
+  })
+
+  test('returns undefined when content is empty', () => {
+    const markdown = ''
+    const tree = parseMarkdownWithFrontmatter(markdown)
+
+    const frontmatter = getFrontmatterNode(tree)
+
+    expect(frontmatter).toBeUndefined()
+  })
+})
+
+describe('RELATIVE_URL_PATTERN', () => {
+  test('matches paths starting with ./', () => {
+    expect(RELATIVE_URL_PATTERN.test('./file.md')).toBe(true)
+    expect(RELATIVE_URL_PATTERN.test('./path/to/file.md')).toBe(true)
+  })
+
+  test('matches paths starting with ../', () => {
+    expect(RELATIVE_URL_PATTERN.test('../file.md')).toBe(true)
+    expect(RELATIVE_URL_PATTERN.test('../parent/file.md')).toBe(true)
+    expect(RELATIVE_URL_PATTERN.test('../../grandparent/file.md')).toBe(true)
+  })
+
+  test('does not match absolute paths', () => {
+    expect(RELATIVE_URL_PATTERN.test('/absolute/path.md')).toBe(false)
+  })
+
+  test('does not match paths without leading dot', () => {
+    expect(RELATIVE_URL_PATTERN.test('path/to/file.md')).toBe(false)
+    expect(RELATIVE_URL_PATTERN.test('file.md')).toBe(false)
+  })
+
+  test('does not match URLs', () => {
+    expect(RELATIVE_URL_PATTERN.test('https://example.com/file.md')).toBe(false)
+    expect(RELATIVE_URL_PATTERN.test('http://example.com/file.md')).toBe(false)
+  })
+
+  test('does not match standalone dots', () => {
+    expect(RELATIVE_URL_PATTERN.test('.')).toBe(false)
+    expect(RELATIVE_URL_PATTERN.test('..')).toBe(false)
+  })
+})
+
+describe('RELATIVE_URL_PATTERN', () => {
+  test('matches paths starting with ./', () => {
+    expect(RELATIVE_URL_PATTERN.test('./file.md')).toBe(true)
+    expect(RELATIVE_URL_PATTERN.test('./path/to/file.md')).toBe(true)
+  })
+
+  test('matches paths starting with ../', () => {
+    expect(RELATIVE_URL_PATTERN.test('../file.md')).toBe(true)
+    expect(RELATIVE_URL_PATTERN.test('../parent/file.md')).toBe(true)
+    expect(RELATIVE_URL_PATTERN.test('../../grandparent/file.md')).toBe(true)
+  })
+
+  test('does not match absolute paths', () => {
+    expect(RELATIVE_URL_PATTERN.test('/absolute/path.md')).toBe(false)
+  })
+
+  test('does not match paths without leading dot', () => {
+    expect(RELATIVE_URL_PATTERN.test('path/to/file.md')).toBe(false)
+    expect(RELATIVE_URL_PATTERN.test('file.md')).toBe(false)
+  })
+
+  test('does not match URLs', () => {
+    expect(RELATIVE_URL_PATTERN.test('https://example.com/file.md')).toBe(false)
+    expect(RELATIVE_URL_PATTERN.test('http://example.com/file.md')).toBe(false)
+  })
+
+  test('does not match standalone dots', () => {
+    expect(RELATIVE_URL_PATTERN.test('.')).toBe(false)
+    expect(RELATIVE_URL_PATTERN.test('..')).toBe(false)
   })
 })

--- a/packages/doom/test/plugins/replace/utils.spec.ts
+++ b/packages/doom/test/plugins/replace/utils.spec.ts
@@ -265,35 +265,3 @@ describe('RELATIVE_URL_PATTERN', () => {
     expect(RELATIVE_URL_PATTERN.test('..')).toBe(false)
   })
 })
-
-describe('RELATIVE_URL_PATTERN', () => {
-  test('matches paths starting with ./', () => {
-    expect(RELATIVE_URL_PATTERN.test('./file.md')).toBe(true)
-    expect(RELATIVE_URL_PATTERN.test('./path/to/file.md')).toBe(true)
-  })
-
-  test('matches paths starting with ../', () => {
-    expect(RELATIVE_URL_PATTERN.test('../file.md')).toBe(true)
-    expect(RELATIVE_URL_PATTERN.test('../parent/file.md')).toBe(true)
-    expect(RELATIVE_URL_PATTERN.test('../../grandparent/file.md')).toBe(true)
-  })
-
-  test('does not match absolute paths', () => {
-    expect(RELATIVE_URL_PATTERN.test('/absolute/path.md')).toBe(false)
-  })
-
-  test('does not match paths without leading dot', () => {
-    expect(RELATIVE_URL_PATTERN.test('path/to/file.md')).toBe(false)
-    expect(RELATIVE_URL_PATTERN.test('file.md')).toBe(false)
-  })
-
-  test('does not match URLs', () => {
-    expect(RELATIVE_URL_PATTERN.test('https://example.com/file.md')).toBe(false)
-    expect(RELATIVE_URL_PATTERN.test('http://example.com/file.md')).toBe(false)
-  })
-
-  test('does not match standalone dots', () => {
-    expect(RELATIVE_URL_PATTERN.test('.')).toBe(false)
-    expect(RELATIVE_URL_PATTERN.test('..')).toBe(false)
-  })
-})

--- a/packages/doom/test/plugins/shared.spec.ts
+++ b/packages/doom/test/plugins/shared.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from '@rstest/core'
+
+import { getASTNodeImport } from '#plugins/shared.ts'
+
+describe('getASTNodeImport', () => {
+  describe('with string name (default import)', () => {
+    test('creates mdxjsEsm node with correct type', () => {
+      const result = getASTNodeImport('MyComponent', './component.tsx')
+
+      expect(result.type).toBe('mdxjsEsm')
+    })
+
+    test('generates correct import statement value', () => {
+      const result = getASTNodeImport('MyComponent', './component.tsx')
+
+      expect(result.value).toBe('import MyComponent from "./component.tsx"')
+    })
+
+    test('creates ImportDefaultSpecifier in estree', () => {
+      const result = getASTNodeImport('MyComponent', './component.tsx')
+      const importDecl = result.data!.estree!.body[0] as {
+        specifiers: Array<{ type: string; local: { name: string } }>
+      }
+
+      expect(importDecl.specifiers).toHaveLength(1)
+      expect(importDecl.specifiers[0].type).toBe('ImportDefaultSpecifier')
+      expect(importDecl.specifiers[0].local.name).toBe('MyComponent')
+    })
+
+    test('sets source correctly', () => {
+      const result = getASTNodeImport('image', './test.png')
+      const importDecl = result.data!.estree!.body[0] as {
+        source: { value: string; raw: string }
+      }
+
+      expect(importDecl.source.value).toBe('./test.png')
+      expect(importDecl.source.raw).toBe('"./test.png"')
+    })
+
+    test('handles paths with special characters', () => {
+      const result = getASTNodeImport('data', './path/to/file with spaces.json')
+
+      expect(result.value).toBe(
+        'import data from "./path/to/file with spaces.json"',
+      )
+    })
+  })
+
+  describe('with object name (named imports)', () => {
+    test('generates named import with same local name', () => {
+      const result = getASTNodeImport({ Button: 'Button' }, './components')
+
+      expect(result.value).toBe('import {Button} from "./components"')
+    })
+
+    test('generates named import with alias', () => {
+      const result = getASTNodeImport({ default: 'MyDefault' }, './module')
+
+      expect(result.value).toBe('import {default as MyDefault} from "./module"')
+    })
+
+    test('generates named import with null local (uses imported name)', () => {
+      const result = getASTNodeImport({ Button: null }, './components')
+
+      expect(result.value).toBe('import {Button} from "./components"')
+    })
+
+    test('generates multiple named imports', () => {
+      const result = getASTNodeImport(
+        { Button: 'Button', Input: 'TextInput' },
+        './components',
+      )
+
+      expect(result.value).toBe(
+        'import {Button,Input as TextInput} from "./components"',
+      )
+    })
+
+    test('creates ImportSpecifiers in estree for named imports', () => {
+      const result = getASTNodeImport(
+        { Button: 'MyButton', Icon: null },
+        './components',
+      )
+      const importDecl = result.data!.estree!.body[0] as {
+        specifiers: Array<{
+          type: string
+          imported: { name: string }
+          local: { name: string }
+        }>
+      }
+
+      expect(importDecl.specifiers).toHaveLength(2)
+      expect(importDecl.specifiers[0].type).toBe('ImportSpecifier')
+      expect(importDecl.specifiers[0].imported.name).toBe('Button')
+      expect(importDecl.specifiers[0].local.name).toBe('MyButton')
+      expect(importDecl.specifiers[1].imported.name).toBe('Icon')
+      expect(importDecl.specifiers[1].local.name).toBe('Icon')
+    })
+
+    test('handles empty object', () => {
+      const result = getASTNodeImport({}, './module')
+
+      expect(result.value).toBe('import {} from "./module"')
+    })
+  })
+
+  describe('estree structure', () => {
+    test('has Program type', () => {
+      const result = getASTNodeImport('test', './test')
+
+      expect(result.data!.estree!.type).toBe('Program')
+    })
+
+    test('has module sourceType', () => {
+      const result = getASTNodeImport('test', './test')
+
+      expect(result.data!.estree!.sourceType).toBe('module')
+    })
+
+    test('has ImportDeclaration in body', () => {
+      const result = getASTNodeImport('test', './test')
+      const body = result.data!.estree!.body[0] as { type: string }
+
+      expect(body.type).toBe('ImportDeclaration')
+    })
+
+    test('has empty attributes array', () => {
+      const result = getASTNodeImport('test', './test')
+      const importDecl = result.data!.estree!.body[0] as {
+        attributes: unknown[]
+      }
+
+      expect(importDecl.attributes).toEqual([])
+    })
+  })
+})

--- a/packages/doom/test/plugins/shiki/transformers/callouts.spec.ts
+++ b/packages/doom/test/plugins/shiki/transformers/callouts.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from '@rstest/core'
+import { codeToHtml } from 'shiki'
+
+import { createTransformerCallouts } from '#plugins/shiki/transformers/callouts.ts'
+
+describe('createTransformerCallouts', () => {
+  test('creates transformer with default options', () => {
+    const transformer = createTransformerCallouts()
+
+    expect(transformer).toBeDefined()
+    expect(transformer.name).toBe('shiki-transformer:callouts')
+  })
+
+  test('creates transformer with custom classActiveLine', () => {
+    const transformer = createTransformerCallouts({
+      classActiveLine: 'custom-callout',
+    })
+
+    expect(transformer).toBeDefined()
+    expect(transformer.name).toBe('shiki-transformer:callouts')
+  })
+
+  test('creates transformer with custom classActivePre', () => {
+    const transformer = createTransformerCallouts({
+      classActivePre: 'custom-has-callouts',
+    })
+
+    expect(transformer).toBeDefined()
+    expect(transformer.name).toBe('shiki-transformer:callouts')
+  })
+
+  test('creates transformer with all custom options', () => {
+    const transformer = createTransformerCallouts({
+      classActiveLine: 'my-callout',
+      classActivePre: 'my-has-callouts',
+    })
+
+    expect(transformer).toBeDefined()
+    expect(transformer.name).toBe('shiki-transformer:callouts')
+  })
+
+  test('transformer adds callout class to marked lines', async () => {
+    const transformer = createTransformerCallouts()
+
+    const code = `const x = 1 // [!code callout]
+const y = 2`
+
+    const html = await codeToHtml(code, {
+      lang: 'javascript',
+      theme: 'github-light',
+      transformers: [transformer],
+    })
+
+    expect(html).toContain('callout')
+  })
+
+  test('transformer adds has-callouts class to pre element', async () => {
+    const transformer = createTransformerCallouts()
+
+    const code = `const x = 1 // [!code callout]`
+
+    const html = await codeToHtml(code, {
+      lang: 'javascript',
+      theme: 'github-light',
+      transformers: [transformer],
+    })
+
+    expect(html).toContain('has-callouts')
+  })
+
+  test('transformer uses custom classes when provided', async () => {
+    const transformer = createTransformerCallouts({
+      classActiveLine: 'custom-line',
+      classActivePre: 'custom-pre',
+    })
+
+    const code = `const x = 1 // [!code callout]`
+
+    const html = await codeToHtml(code, {
+      lang: 'javascript',
+      theme: 'github-light',
+      transformers: [transformer],
+    })
+
+    expect(html).toContain('custom-line')
+    expect(html).toContain('custom-pre')
+  })
+
+  test('transformer does not add classes when no callout annotation', async () => {
+    const transformer = createTransformerCallouts()
+
+    const code = `const x = 1
+const y = 2`
+
+    const html = await codeToHtml(code, {
+      lang: 'javascript',
+      theme: 'github-light',
+      transformers: [transformer],
+    })
+
+    expect(html).not.toContain('has-callouts')
+  })
+})

--- a/packages/doom/test/plugins/shiki/transformers/callouts.spec.ts
+++ b/packages/doom/test/plugins/shiki/transformers/callouts.spec.ts
@@ -51,7 +51,7 @@ const y = 2`
       transformers: [transformer],
     })
 
-    expect(html).toContain('callout')
+    expect(html).toContain('<span class="line callout"')
   })
 
   test('transformer adds has-callouts class to pre element', async () => {
@@ -65,7 +65,7 @@ const y = 2`
       transformers: [transformer],
     })
 
-    expect(html).toContain('has-callouts')
+    expect(html).toContain('<pre class="shiki github-light has-callouts"')
   })
 
   test('transformer uses custom classes when provided', async () => {

--- a/packages/doom/test/remark-lint/utils.spec.ts
+++ b/packages/doom/test/remark-lint/utils.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from '@rstest/core'
+
+import { PUNCTUATION_REGEX } from '#remark-lint/utils.ts'
+
+describe('PUNCTUATION_REGEX', () => {
+  test('matches common punctuation marks', () => {
+    expect(PUNCTUATION_REGEX.test('.')).toBe(true)
+    expect(PUNCTUATION_REGEX.test(',')).toBe(true)
+    expect(PUNCTUATION_REGEX.test(';')).toBe(true)
+    expect(PUNCTUATION_REGEX.test(':')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('!')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('?')).toBe(true)
+  })
+
+  test('matches quotation marks', () => {
+    expect(PUNCTUATION_REGEX.test('"')).toBe(true)
+    expect(PUNCTUATION_REGEX.test("'")).toBe(true)
+  })
+
+  test('matches brackets and parentheses', () => {
+    expect(PUNCTUATION_REGEX.test('(')).toBe(true)
+    expect(PUNCTUATION_REGEX.test(')')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('[')).toBe(true)
+    expect(PUNCTUATION_REGEX.test(']')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('{')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('}')).toBe(true)
+  })
+
+  test('matches dashes and hyphens', () => {
+    expect(PUNCTUATION_REGEX.test('-')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('—')).toBe(true) // em dash
+    expect(PUNCTUATION_REGEX.test('–')).toBe(true) // en dash
+  })
+
+  test('matches Chinese punctuation', () => {
+    expect(PUNCTUATION_REGEX.test('。')).toBe(true) // Chinese period
+    expect(PUNCTUATION_REGEX.test('，')).toBe(true) // Chinese comma
+    expect(PUNCTUATION_REGEX.test('！')).toBe(true) // Chinese exclamation
+    expect(PUNCTUATION_REGEX.test('？')).toBe(true) // Chinese question
+    expect(PUNCTUATION_REGEX.test('；')).toBe(true) // Chinese semicolon
+    expect(PUNCTUATION_REGEX.test('：')).toBe(true) // Chinese colon
+    expect(PUNCTUATION_REGEX.test('、')).toBe(true) // Chinese enumeration comma
+  })
+
+  test('matches Chinese brackets', () => {
+    expect(PUNCTUATION_REGEX.test('（')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('）')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('【')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('】')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('「')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('」')).toBe(true)
+  })
+
+  test('does not match letters', () => {
+    expect(PUNCTUATION_REGEX.test('a')).toBe(false)
+    expect(PUNCTUATION_REGEX.test('Z')).toBe(false)
+    expect(PUNCTUATION_REGEX.test('中')).toBe(false)
+  })
+
+  test('does not match numbers', () => {
+    expect(PUNCTUATION_REGEX.test('0')).toBe(false)
+    expect(PUNCTUATION_REGEX.test('9')).toBe(false)
+  })
+
+  test('does not match spaces', () => {
+    expect(PUNCTUATION_REGEX.test(' ')).toBe(false)
+    expect(PUNCTUATION_REGEX.test('\t')).toBe(false)
+    expect(PUNCTUATION_REGEX.test('\n')).toBe(false)
+  })
+
+  test('matches special symbols', () => {
+    expect(PUNCTUATION_REGEX.test('@')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('#')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('&')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('*')).toBe(true)
+    expect(PUNCTUATION_REGEX.test('/')).toBe(true)
+  })
+
+  test('matches ellipsis', () => {
+    expect(PUNCTUATION_REGEX.test('…')).toBe(true)
+  })
+
+  test('can be used to find first punctuation in string', () => {
+    const match = '你好，世界！'.match(PUNCTUATION_REGEX)
+    expect(match).toBeTruthy()
+    expect(match![0]).toBe('，')
+  })
+})

--- a/packages/doom/test/shared/constants.spec.ts
+++ b/packages/doom/test/shared/constants.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from '@rstest/core'
+
+import {
+  ACP_BASE,
+  APIS_ROUTES,
+  FALSY_VALUES,
+  JS_STR_FALSY_VALUES,
+  Language,
+  SUPPORTED_LANGUAGES,
+  TITLE_TRANSLATION_MAP,
+  TRUTHY_VALUES,
+  UNVERSIONED,
+  UNVERSIONED_PREFIX,
+} from '#shared/constants.ts'
+
+describe('ACP_BASE', () => {
+  test('has correct value', () => {
+    expect(ACP_BASE).toBe('/container_platform/')
+  })
+})
+
+describe('FALSY_VALUES', () => {
+  test('contains expected falsy values', () => {
+    expect(FALSY_VALUES.has(null)).toBe(true)
+    expect(FALSY_VALUES.has(undefined)).toBe(true)
+    expect(FALSY_VALUES.has('')).toBe(true)
+    expect(FALSY_VALUES.has('0')).toBe(true)
+    expect(FALSY_VALUES.has('false')).toBe(true)
+    expect(FALSY_VALUES.has('no')).toBe(true)
+    expect(FALSY_VALUES.has('off')).toBe(true)
+    expect(FALSY_VALUES.has('n')).toBe(true)
+    expect(FALSY_VALUES.has('f')).toBe(true)
+  })
+
+  test('does not contain truthy values', () => {
+    expect(FALSY_VALUES.has('1')).toBe(false)
+    expect(FALSY_VALUES.has('true')).toBe(false)
+    expect(FALSY_VALUES.has('yes')).toBe(false)
+  })
+})
+
+describe('TRUTHY_VALUES', () => {
+  test('contains expected truthy values', () => {
+    expect(TRUTHY_VALUES.has('1')).toBe(true)
+    expect(TRUTHY_VALUES.has('true')).toBe(true)
+    expect(TRUTHY_VALUES.has('yes')).toBe(true)
+    expect(TRUTHY_VALUES.has('on')).toBe(true)
+    expect(TRUTHY_VALUES.has('y')).toBe(true)
+    expect(TRUTHY_VALUES.has('t')).toBe(true)
+  })
+
+  test('does not contain falsy values', () => {
+    expect(TRUTHY_VALUES.has('0')).toBe(false)
+    expect(TRUTHY_VALUES.has('false')).toBe(false)
+    expect(TRUTHY_VALUES.has('no')).toBe(false)
+  })
+})
+
+describe('JS_STR_FALSY_VALUES', () => {
+  test('contains JS string falsy values', () => {
+    expect(JS_STR_FALSY_VALUES.has(null)).toBe(true)
+    expect(JS_STR_FALSY_VALUES.has(undefined)).toBe(true)
+    expect(JS_STR_FALSY_VALUES.has('')).toBe(true)
+    expect(JS_STR_FALSY_VALUES.has('0')).toBe(true)
+    expect(JS_STR_FALSY_VALUES.has('false')).toBe(true)
+    expect(JS_STR_FALSY_VALUES.has('null')).toBe(true)
+    expect(JS_STR_FALSY_VALUES.has('undefined')).toBe(true)
+  })
+})
+
+describe('APIS_ROUTES', () => {
+  test('contains expected API routes', () => {
+    expect(APIS_ROUTES.has('apis/**')).toBe(true)
+    expect(APIS_ROUTES.has('*/apis/**')).toBe(true)
+  })
+
+  test('has exactly 2 routes', () => {
+    expect(APIS_ROUTES.size).toBe(2)
+  })
+})
+
+describe('Language', () => {
+  test('has correct language mappings', () => {
+    expect(Language.en).toBe('English')
+    expect(Language.zh).toBe('Chinese')
+    expect(Language.ru).toBe('Russian')
+  })
+})
+
+describe('SUPPORTED_LANGUAGES', () => {
+  test('contains all language keys', () => {
+    expect(SUPPORTED_LANGUAGES).toContain('en')
+    expect(SUPPORTED_LANGUAGES).toContain('zh')
+    expect(SUPPORTED_LANGUAGES).toContain('ru')
+  })
+
+  test('has correct length', () => {
+    expect(SUPPORTED_LANGUAGES).toHaveLength(3)
+  })
+})
+
+describe('TITLE_TRANSLATION_MAP', () => {
+  test('is an array of translation objects', () => {
+    expect(Array.isArray(TITLE_TRANSLATION_MAP)).toBe(true)
+    expect(TITLE_TRANSLATION_MAP.length).toBeGreaterThan(0)
+  })
+
+  test('contains Navigation translations', () => {
+    const nav = TITLE_TRANSLATION_MAP.find((t) => t.en === 'Navigation')
+    expect(nav).toBeDefined()
+    expect(nav!.zh).toBe('导航')
+    expect(nav!.ru).toBe('Навигация')
+  })
+
+  test('contains Overview translations', () => {
+    const overview = TITLE_TRANSLATION_MAP.find((t) => t.en === 'Overview')
+    expect(overview).toBeDefined()
+    expect(overview!.zh).toBe('概览')
+    expect(overview!.ru).toBe('Обзор')
+  })
+
+  test('contains FAQ translations', () => {
+    const faq = TITLE_TRANSLATION_MAP.find((t) => t.en === 'FAQ')
+    expect(faq).toBeDefined()
+    expect(faq!.zh).toBe('常见问题')
+  })
+})
+
+describe('UNVERSIONED', () => {
+  test('has correct value', () => {
+    expect(UNVERSIONED).toBe('unversioned')
+  })
+})
+
+describe('UNVERSIONED_PREFIX', () => {
+  test('has correct value', () => {
+    expect(UNVERSIONED_PREFIX).toBe('unversioned-')
+  })
+
+  test('starts with UNVERSIONED', () => {
+    expect(UNVERSIONED_PREFIX.startsWith(UNVERSIONED)).toBe(true)
+  })
+})

--- a/packages/doom/test/shared/helpers.spec.ts
+++ b/packages/doom/test/shared/helpers.spec.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from '@rstest/core'
+
+import {
+  getPdfName,
+  getUnversionedVersion,
+  isExplicitlyUnversioned,
+  isUnversioned,
+  matchNavbar,
+  normalizeSlash,
+  removeBothEndsSlashes,
+  withoutBase,
+} from '#shared/helpers.ts'
+
+describe('removeBothEndsSlashes', () => {
+  test('removes leading slash', () => {
+    expect(removeBothEndsSlashes('/hello')).toBe('hello')
+  })
+
+  test('removes trailing slash', () => {
+    expect(removeBothEndsSlashes('hello/')).toBe('hello')
+  })
+
+  test('removes both leading and trailing slashes', () => {
+    expect(removeBothEndsSlashes('/hello/')).toBe('hello')
+  })
+
+  test('keeps internal slashes', () => {
+    expect(removeBothEndsSlashes('/hello/world/')).toBe('hello/world')
+  })
+
+  test('returns empty string for undefined', () => {
+    expect(removeBothEndsSlashes(undefined)).toBe('')
+  })
+
+  test('returns empty string for empty string', () => {
+    expect(removeBothEndsSlashes('')).toBe('')
+  })
+
+  test('handles single slash', () => {
+    expect(removeBothEndsSlashes('/')).toBe('')
+  })
+})
+
+describe('getPdfName', () => {
+  test('generates pdf name with base', () => {
+    expect(getPdfName('en', '/docs')).toBe('/docs-en.pdf')
+  })
+
+  test('generates pdf name with title when no base', () => {
+    expect(getPdfName('zh', undefined, 'my-docs')).toBe('/my-docs-zh.pdf')
+  })
+
+  test('uses exported as fallback', () => {
+    expect(getPdfName('en')).toBe('/exported-en.pdf')
+  })
+
+  test('strips slashes from base', () => {
+    expect(getPdfName('en', '/my/docs/')).toBe('/my/docs-en.pdf')
+  })
+
+  test('handles empty base', () => {
+    expect(getPdfName('zh', '', 'title')).toBe('/title-zh.pdf')
+  })
+})
+
+describe('isExplicitlyUnversioned', () => {
+  test('returns true for unversioned', () => {
+    expect(isExplicitlyUnversioned('unversioned')).toBe(true)
+  })
+
+  test('returns true for unversioned- prefix', () => {
+    expect(isExplicitlyUnversioned('unversioned-foo')).toBe(true)
+  })
+
+  test('returns false for regular version', () => {
+    expect(isExplicitlyUnversioned('v1.0.0')).toBe(false)
+  })
+
+  test('returns false for undefined', () => {
+    expect(isExplicitlyUnversioned(undefined)).toBe(false)
+  })
+})
+
+describe('isUnversioned', () => {
+  test('returns true for undefined', () => {
+    expect(isUnversioned(undefined)).toBe(true)
+  })
+
+  test('returns true for empty string', () => {
+    expect(isUnversioned('')).toBe(true)
+  })
+
+  test('returns true for unversioned', () => {
+    expect(isUnversioned('unversioned')).toBe(true)
+  })
+
+  test('returns true for unversioned- prefix', () => {
+    expect(isUnversioned('unversioned-v2')).toBe(true)
+  })
+
+  test('returns false for regular version', () => {
+    expect(isUnversioned('v1.0.0')).toBe(false)
+  })
+})
+
+describe('getUnversionedVersion', () => {
+  test('returns undefined for empty string', () => {
+    expect(getUnversionedVersion('')).toBeUndefined()
+  })
+
+  test('returns undefined for unversioned', () => {
+    expect(getUnversionedVersion('unversioned')).toBeUndefined()
+  })
+
+  test('extracts version from unversioned- prefix', () => {
+    expect(getUnversionedVersion('unversioned-v2.0')).toBe('v2.0')
+  })
+
+  test('returns version as-is for regular versions', () => {
+    expect(getUnversionedVersion('v1.0.0')).toBe('v1.0.0')
+  })
+
+  test('returns undefined for undefined input', () => {
+    expect(getUnversionedVersion(undefined)).toBeUndefined()
+  })
+})
+
+describe('normalizeSlash', () => {
+  test('adds leading slash', () => {
+    expect(normalizeSlash('path')).toBe('/path')
+  })
+
+  test('removes trailing slash', () => {
+    expect(normalizeSlash('path/')).toBe('/path')
+  })
+
+  test('normalizes both', () => {
+    expect(normalizeSlash('path/')).toBe('/path')
+  })
+
+  test('handles already normalized path', () => {
+    expect(normalizeSlash('/path')).toBe('/path')
+  })
+
+  test('handles path with internal slashes', () => {
+    expect(normalizeSlash('a/b/c/')).toBe('/a/b/c')
+  })
+})
+
+describe('withoutBase', () => {
+  test('removes base from path', () => {
+    expect(withoutBase('/docs/page', '/docs')).toBe('/page')
+  })
+
+  test('handles paths without base', () => {
+    expect(withoutBase('/page', '/other')).toBe('/page')
+  })
+
+  test('normalizes input path', () => {
+    expect(withoutBase('docs/page', '/docs')).toBe('/page')
+  })
+})
+
+describe('matchNavbar', () => {
+  test('matches using link', () => {
+    const item = { link: '/docs', text: 'Docs' }
+    expect(matchNavbar(item, '/base/docs/page', '/base')).toBe(true)
+  })
+
+  test('does not match unrelated path', () => {
+    const item = { link: '/docs', text: 'Docs' }
+    expect(matchNavbar(item, '/base/other', '/base')).toBe(false)
+  })
+
+  test('uses activeMatch over link when provided', () => {
+    const item = { link: '/docs', text: 'Docs', activeMatch: '^/guides' }
+    expect(matchNavbar(item, '/base/guides/getting-started', '/base')).toBe(
+      true,
+    )
+    expect(matchNavbar(item, '/base/docs/intro', '/base')).toBe(false)
+  })
+
+  test('supports regex patterns in activeMatch', () => {
+    const item = { link: '/docs', text: 'Docs', activeMatch: '/docs/(api|ref)' }
+    expect(matchNavbar(item, '/base/docs/api/v1', '/base')).toBe(true)
+    expect(matchNavbar(item, '/base/docs/ref/class', '/base')).toBe(true)
+    expect(matchNavbar(item, '/base/docs/intro', '/base')).toBe(false)
+  })
+})

--- a/packages/doom/test/utils/fs.spec.ts
+++ b/packages/doom/test/utils/fs.spec.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, test } from '@rstest/core'
+
+import { pathExists, readJson } from '#utils/fs.ts'
+
+describe('pathExists', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'doom-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('returns true for existing file', async () => {
+    const filePath = path.join(tempDir, 'test.txt')
+    await fs.writeFile(filePath, 'test')
+
+    expect(await pathExists(filePath)).toBe(true)
+  })
+
+  test('returns true for existing directory', async () => {
+    const dirPath = path.join(tempDir, 'subdir')
+    await fs.mkdir(dirPath)
+
+    expect(await pathExists(dirPath)).toBe(true)
+  })
+
+  test('returns false for non-existing path', async () => {
+    const fakePath = path.join(tempDir, 'nonexistent')
+
+    expect(await pathExists(fakePath)).toBe(false)
+  })
+
+  test('returns true when file matches type "file"', async () => {
+    const filePath = path.join(tempDir, 'test.txt')
+    await fs.writeFile(filePath, 'test')
+
+    expect(await pathExists(filePath, 'file')).toBe(true)
+  })
+
+  test('returns false when directory does not match type "file"', async () => {
+    const dirPath = path.join(tempDir, 'subdir')
+    await fs.mkdir(dirPath)
+
+    expect(await pathExists(dirPath, 'file')).toBe(false)
+  })
+
+  test('returns true when directory matches type "directory"', async () => {
+    const dirPath = path.join(tempDir, 'subdir')
+    await fs.mkdir(dirPath)
+
+    expect(await pathExists(dirPath, 'directory')).toBe(true)
+  })
+
+  test('returns false when file does not match type "directory"', async () => {
+    const filePath = path.join(tempDir, 'test.txt')
+    await fs.writeFile(filePath, 'test')
+
+    expect(await pathExists(filePath, 'directory')).toBe(false)
+  })
+})
+
+describe('readJson', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'doom-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('reads and parses JSON file', async () => {
+    const filePath = path.join(tempDir, 'test.json')
+    const data = { name: 'test', version: '1.0.0' }
+    await fs.writeFile(filePath, JSON.stringify(data))
+
+    const result = await readJson<typeof data>(filePath)
+    expect(result).toEqual(data)
+  })
+
+  test('reads JSON with nested objects', async () => {
+    const filePath = path.join(tempDir, 'nested.json')
+    const data = {
+      level1: {
+        level2: {
+          value: 42,
+        },
+      },
+    }
+    await fs.writeFile(filePath, JSON.stringify(data))
+
+    const result = await readJson<typeof data>(filePath)
+    expect(result.level1.level2.value).toBe(42)
+  })
+
+  test('reads JSON array', async () => {
+    const filePath = path.join(tempDir, 'array.json')
+    const data = [1, 2, 3, 'test']
+    await fs.writeFile(filePath, JSON.stringify(data))
+
+    const result = await readJson<typeof data>(filePath)
+    expect(result).toEqual(data)
+  })
+
+  test('throws error for invalid JSON', async () => {
+    const filePath = path.join(tempDir, 'invalid.json')
+    await fs.writeFile(filePath, 'not valid json')
+
+    await expect(readJson(filePath)).rejects.toThrow()
+  })
+
+  test('throws error for non-existing file', async () => {
+    const filePath = path.join(tempDir, 'nonexistent.json')
+
+    await expect(readJson(filePath)).rejects.toThrow()
+  })
+})

--- a/packages/doom/test/utils/helpers.spec.ts
+++ b/packages/doom/test/utils/helpers.spec.ts
@@ -86,7 +86,7 @@ describe('pkgResolve', () => {
     const result = pkgResolve('src', '..', 'package.json')
 
     expect(result).toContain('package.json')
-    expect(result).not.toContain('src')
+    expect(result).toBe(pkgResolve('package.json'))
   })
 
   test('pkgResolve is one level above baseResolve', () => {

--- a/packages/export/test/helpers.spec.ts
+++ b/packages/export/test/helpers.spec.ts
@@ -1,0 +1,37 @@
+import path from 'node:path'
+
+import { describe, expect, test } from '@rstest/core'
+
+import { pkgResolve } from '#helpers.ts'
+
+describe('pkgResolve', () => {
+  test('resolves to package root', () => {
+    const result = pkgResolve()
+    expect(path.isAbsolute(result)).toBe(true)
+    expect(result).toContain('export')
+  })
+
+  test('resolves single path segment', () => {
+    const result = pkgResolve('src')
+    expect(result).toContain('src')
+    expect(result).toContain('export')
+  })
+
+  test('resolves multiple path segments', () => {
+    const result = pkgResolve('src', 'helpers.ts')
+    expect(result).toContain('src')
+    expect(result).toContain('helpers.ts')
+  })
+
+  test('resolves pyodide directory', () => {
+    const result = pkgResolve('pyodide')
+    expect(result).toContain('pyodide')
+    expect(path.isAbsolute(result)).toBe(true)
+  })
+
+  test('handles parent directory references', () => {
+    const result = pkgResolve('src', '..', 'package.json')
+    expect(result).toContain('package.json')
+    expect(result).not.toContain('src')
+  })
+})

--- a/packages/export/test/helpers.spec.ts
+++ b/packages/export/test/helpers.spec.ts
@@ -32,6 +32,6 @@ describe('pkgResolve', () => {
   test('handles parent directory references', () => {
     const result = pkgResolve('src', '..', 'package.json')
     expect(result).toContain('package.json')
-    expect(result).not.toContain('src')
+    expect(result).toBe(pkgResolve('package.json'))
   })
 })

--- a/packages/export/test/html-export-pdf/utils/fs.spec.ts
+++ b/packages/export/test/html-export-pdf/utils/fs.spec.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, test } from '@rstest/core'
+
+import { writeFileSafe } from '#html-export-pdf/utils/fs.ts'
+
+describe('writeFileSafe', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'doom-export-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  test('writes string content to file', async () => {
+    const filePath = path.join(tempDir, 'test.txt')
+    const content = 'Hello, World!'
+
+    const result = await writeFileSafe(filePath, content)
+
+    expect(result).toBe(true)
+    const written = await fs.readFile(filePath, 'utf-8')
+    expect(written).toBe(content)
+  })
+
+  test('writes buffer content to file', async () => {
+    const filePath = path.join(tempDir, 'test.bin')
+    const content = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f])
+
+    const result = await writeFileSafe(filePath, content)
+
+    expect(result).toBe(true)
+    const written = await fs.readFile(filePath)
+    expect(written).toEqual(content)
+  })
+
+  test('writes Uint8Array content to file', async () => {
+    const filePath = path.join(tempDir, 'test.bin')
+    const content = new Uint8Array([1, 2, 3, 4, 5])
+
+    const result = await writeFileSafe(filePath, content)
+
+    expect(result).toBe(true)
+    const written = await fs.readFile(filePath)
+    expect(new Uint8Array(written)).toEqual(content)
+  })
+
+  test('creates nested directories if they do not exist', async () => {
+    const filePath = path.join(tempDir, 'nested', 'deep', 'folder', 'test.txt')
+    const content = 'nested content'
+
+    const result = await writeFileSafe(filePath, content)
+
+    expect(result).toBe(true)
+    const written = await fs.readFile(filePath, 'utf-8')
+    expect(written).toBe(content)
+  })
+
+  test('writes empty content by default', async () => {
+    const filePath = path.join(tempDir, 'empty.txt')
+
+    const result = await writeFileSafe(filePath)
+
+    expect(result).toBe(true)
+    const written = await fs.readFile(filePath, 'utf-8')
+    expect(written).toBe('')
+  })
+
+  test('overwrites existing file', async () => {
+    const filePath = path.join(tempDir, 'existing.txt')
+    await fs.writeFile(filePath, 'original content')
+
+    const result = await writeFileSafe(filePath, 'new content')
+
+    expect(result).toBe(true)
+    const written = await fs.readFile(filePath, 'utf-8')
+    expect(written).toBe('new content')
+  })
+
+  test('writes to existing directory without creating it again', async () => {
+    const subDir = path.join(tempDir, 'existing-dir')
+    await fs.mkdir(subDir)
+    const filePath = path.join(subDir, 'test.txt')
+
+    const result = await writeFileSafe(filePath, 'content')
+
+    expect(result).toBe(true)
+    const written = await fs.readFile(filePath, 'utf-8')
+    expect(written).toBe('content')
+  })
+})

--- a/packages/export/test/html-export-pdf/utils/getAbsFileName.spec.ts
+++ b/packages/export/test/html-export-pdf/utils/getAbsFileName.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from '@rstest/core'
+
+import { getAbsFileName } from '#html-export-pdf/utils/getAbsFileName.ts'
+
+describe('getAbsFileName', () => {
+  test('converts file URL to path', () => {
+    const fileUrl = 'file:///Users/test/project/file.ts'
+    const result = getAbsFileName(fileUrl)
+
+    expect(result).toBe('/Users/test/project/file.ts')
+  })
+
+  test('handles Windows-style file URL', () => {
+    const fileUrl = 'file:///C:/Users/test/project/file.ts'
+    const result = getAbsFileName(fileUrl)
+
+    // On POSIX systems, this will keep the /C: prefix
+    expect(result).toContain('Users/test/project/file.ts')
+  })
+
+  test('handles URL with spaces', () => {
+    const fileUrl = 'file:///Users/test/my%20project/file.ts'
+    const result = getAbsFileName(fileUrl)
+
+    expect(result).toContain('my project')
+  })
+
+  test('returns absolute path', () => {
+    const fileUrl = 'file:///absolute/path/file.js'
+    const result = getAbsFileName(fileUrl)
+
+    expect(result.startsWith('/')).toBe(true)
+  })
+})

--- a/packages/export/test/html-export-pdf/utils/getDirname.spec.ts
+++ b/packages/export/test/html-export-pdf/utils/getDirname.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from '@rstest/core'
+
+import { getDirname } from '#html-export-pdf/utils/getDirname.ts'
+
+describe('getDirname', () => {
+  test('returns directory name from file URL', () => {
+    const fileUrl = 'file:///Users/test/project/file.ts'
+    const result = getDirname(fileUrl)
+
+    expect(result).toBe('/Users/test/project')
+  })
+
+  test('handles nested paths', () => {
+    const fileUrl = 'file:///a/b/c/d/file.js'
+    const result = getDirname(fileUrl)
+
+    expect(result).toBe('/a/b/c/d')
+  })
+
+  test('handles URL with spaces', () => {
+    const fileUrl = 'file:///Users/test/my%20project/file.ts'
+    const result = getDirname(fileUrl)
+
+    expect(result).toContain('my project')
+    expect(result).not.toContain('file.ts')
+  })
+
+  test('returns parent directory', () => {
+    const fileUrl = 'file:///single/file.txt'
+    const result = getDirname(fileUrl)
+
+    expect(result).toBe('/single')
+  })
+})

--- a/packages/export/test/html-export-pdf/utils/optionsCustomProcessing.spec.ts
+++ b/packages/export/test/html-export-pdf/utils/optionsCustomProcessing.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from '@rstest/core'
+
+import {
+  collectParameters,
+  commaSeparatedList,
+} from '#html-export-pdf/utils/optionsCustomProcessing.ts'
+
+describe('collectParameters', () => {
+  test('adds value to empty array', () => {
+    const result = collectParameters('first', [])
+    expect(result).toEqual(['first'])
+  })
+
+  test('adds value to existing array', () => {
+    const result = collectParameters('third', ['first', 'second'])
+    expect(result).toEqual(['first', 'second', 'third'])
+  })
+
+  test('preserves order of existing elements', () => {
+    let result = collectParameters('a', [])
+    result = collectParameters('b', result)
+    result = collectParameters('c', result)
+    expect(result).toEqual(['a', 'b', 'c'])
+  })
+
+  test('handles empty string value', () => {
+    const result = collectParameters('', ['existing'])
+    expect(result).toEqual(['existing', ''])
+  })
+
+  test('does not modify original array', () => {
+    const original = ['first', 'second']
+    const result = collectParameters('third', original)
+    expect(original).toEqual(['first', 'second'])
+    expect(result).not.toBe(original)
+  })
+})
+
+describe('commaSeparatedList', () => {
+  test('splits single value', () => {
+    const result = commaSeparatedList('item')
+    expect(result).toEqual(['item'])
+  })
+
+  test('splits multiple comma-separated values', () => {
+    const result = commaSeparatedList('a,b,c')
+    expect(result).toEqual(['a', 'b', 'c'])
+  })
+
+  test('preserves whitespace around values', () => {
+    const result = commaSeparatedList('a, b, c')
+    expect(result).toEqual(['a', ' b', ' c'])
+  })
+
+  test('handles empty string', () => {
+    const result = commaSeparatedList('')
+    expect(result).toEqual([''])
+  })
+
+  test('handles consecutive commas', () => {
+    const result = commaSeparatedList('a,,b')
+    expect(result).toEqual(['a', '', 'b'])
+  })
+
+  test('handles trailing comma', () => {
+    const result = commaSeparatedList('a,b,')
+    expect(result).toEqual(['a', 'b', ''])
+  })
+
+  test('handles leading comma', () => {
+    const result = commaSeparatedList(',a,b')
+    expect(result).toEqual(['', 'a', 'b'])
+  })
+})

--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from '@rstest/core'
 
-export default defineConfig({
-  testEnvironment: 'node',
-})
+export default defineConfig({})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,7 +1885,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28":
+"@jridgewell/trace-mapping@npm:^0.3.23, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28":
   version: 0.3.31
   resolution: "@jridgewell/trace-mapping@npm:0.3.31"
   dependencies:
@@ -2991,6 +2991,21 @@ __metadata:
   bin:
     rstest: bin/rstest.js
   checksum: 10c0/28fefc191f3a713310455f69357d27e982acae8d8df2ec1cc5c6b9eafeb38b21c417b4897afbd0056b0efc2f1e7ca9cffce1b3190a0b914a454ec9013687c85e
+  languageName: node
+  linkType: hard
+
+"@rstest/coverage-istanbul@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@rstest/coverage-istanbul@npm:0.3.1"
+  dependencies:
+    istanbul-lib-coverage: "npm:^3.2.2"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-lib-source-maps: "npm:^5.0.6"
+    istanbul-reports: "npm:^3.2.0"
+    swc-plugin-coverage-instrument: "npm:0.0.32"
+  peerDependencies:
+    "@rstest/core": ~0.9.6
+  checksum: 10c0/7b0e6baba10e03ab4c890118edf096e238193184a24ed3f7c8980a1a7073bcb11153404a605731a6b74da8adc91b8d90e099d40bf59bacc5a691d466447c9294
   languageName: node
   linkType: hard
 
@@ -4552,6 +4567,7 @@ __metadata:
     "@changesets/changelog-github": "npm:^0.6.0"
     "@changesets/cli": "npm:^2.30.0"
     "@rstest/core": "npm:^0.9.6"
+    "@rstest/coverage-istanbul": "npm:^0.3.1"
     "@swc-node/register": "npm:^1.11.1"
     "@swc/core": "npm:^1.15.24"
     "@types/cli-progress": "npm:^3.11.6"
@@ -7441,6 +7457,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
+  languageName: node
+  linkType: hard
+
 "html-tag-names@npm:^2.1.0":
   version: 2.1.0
   resolution: "html-tag-names@npm:2.1.0"
@@ -7817,6 +7840,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 10c0/6c7ff2106769e5f592ded1fb418f9f73b4411fd5a084387a5410538332b6567cd1763ff6b6cadca9b9eb2c443cce2f7ea7d7f1b8d315f9ce58539793b1e0922b
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: "npm:^3.0.0"
+    make-dir: "npm:^4.0.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/84323afb14392de8b6a5714bd7e9af845cfbd56cfe71ed276cda2f5f1201aea673c7111901227ee33e68e4364e288d73861eb2ed48f6679d1e69a43b6d9b3ba7
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-source-maps@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "istanbul-lib-source-maps@npm:5.0.6"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.23"
+    debug: "npm:^4.1.1"
+    istanbul-lib-coverage: "npm:^3.0.0"
+  checksum: 10c0/ffe75d70b303a3621ee4671554f306e0831b16f39ab7f4ab52e54d356a5d33e534d97563e318f1333a6aae1d42f91ec49c76b6cd3f3fb378addcb5c81da0255f
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "istanbul-reports@npm:3.2.0"
+  dependencies:
+    html-escaper: "npm:^2.0.0"
+    istanbul-lib-report: "npm:^3.0.0"
+  checksum: 10c0/d596317cfd9c22e1394f22a8d8ba0303d2074fe2e971887b32d870e4b33f8464b10f8ccbe6847808f7db485f084eba09e6c2ed706b3a978e4b52f07085b8f9bc
+  languageName: node
+  linkType: hard
+
 "jackspeak@npm:^3.1.2":
   version: 3.4.3
   resolution: "jackspeak@npm:3.4.3"
@@ -8164,6 +8226,15 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: "npm:^7.5.3"
+  checksum: 10c0/69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
   languageName: node
   linkType: hard
 
@@ -11637,6 +11708,13 @@ __metadata:
     oas-validate: oas-validate.js
     swagger2openapi: swagger2openapi.js
   checksum: 10c0/441a4d3a7d353f99395b14a0c8d6124be6390f2f8aa53336905e7314a7f80b66f5f2a40ac0dc2dbe2f7bc01f52a223a94f54a2ece345095fd3ad8ae8b03d688b
+  languageName: node
+  linkType: hard
+
+"swc-plugin-coverage-instrument@npm:0.0.32":
+  version: 0.0.32
+  resolution: "swc-plugin-coverage-instrument@npm:0.0.32"
+  checksum: 10c0/c58fc5df25529e7b9aad8e9d7e088e5699bfa321dd8a7b6e624a9fc7e6f594a15a469fc878a0100cf3760e03e2e11ae8baf36db16fbe743a96ca0e29440c61c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Add 61 new unit tests to improve test coverage
- Overall statement coverage: ~36.4% → ~41.04%
- Total tests: 271 → 332

## New Test Files

### doom package

| Test File | Source File | Coverage Change |
|-----------|-------------|-----------------|
| `test/plugins/shiki/transformers/callouts.spec.ts` | `callouts.ts` | 33% → 100% |
| `test/plugins/replace/rehype-normalize-link.spec.ts` | `rehype-normalize-link.ts` | 17% → 100% |
| `test/plugins/shared.spec.ts` | `shared.ts` | 0% → 100% |
| `test/plugins/mermaid/remark-mermaid.spec.ts` | `remark-mermaid.ts` | 0% → 100% |
| `test/plugins/directives/remark-directives.spec.ts` | `remark-directives.ts` | 0% → 100% |
| `test/plugins/auto-toc/remark-auto-toc.spec.ts` | `remark-auto-toc.ts` | 0% → 100% |
| `test/plugins/auto-sidebar/utils.spec.ts` | `utils.ts` | added combineWalkResult tests |
| `test/cli/helpers.spec.ts` | `helpers.ts` | CLI helper functions |
| `test/shared/constants.spec.ts` | `constants.ts` | shared constants |
| `test/shared/helpers.spec.ts` | `helpers.ts` | shared helper functions |
| `test/utils/fs.spec.ts` | `fs.ts` | pathExists, readJson |
| `test/remark-lint/utils.spec.ts` | `utils.ts` | PUNCTUATION_REGEX |

### export package

| Test File | Source File |
|-----------|-------------|
| `test/helpers.spec.ts` | `helpers.ts` |
| `test/html-export-pdf/utils/fs.spec.ts` | `fs.ts` |
| `test/html-export-pdf/utils/getAbsFileName.spec.ts` | `getAbsFileName.ts` |
| `test/html-export-pdf/utils/getDirname.spec.ts` | `getDirname.ts` |
| `test/html-export-pdf/utils/optionsCustomProcessing.spec.ts` | `optionsCustomProcessing.ts` |

## Testing

All 332 tests pass with `yarn test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded comprehensive test coverage across CLI helpers, plugins, utilities, and shared modules.

* **Chores**
  * Updated test script to include coverage reporting with Istanbul support.
  * Removed watch test script in favor of standard test execution.
  * Updated ESLint configuration and test runner settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->