### PR TITLE
feat(remark-lint): add title-required rule

### DIFF
--- a/.changeset/smart-birds-hug.md
+++ b/.changeset/smart-birds-hug.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": minor
+---
+
+feat(remark-lint): add title-required rule

--- a/packages/doom/src/remark-lint/index.ts
+++ b/packages/doom/src/remark-lint/index.ts
@@ -18,6 +18,7 @@ export * from './no-paragraph-indent.ts'
 export * from './no-unmatched-anchor.ts'
 export * from './site.ts'
 export * from './table-size.ts'
+export * from './title-required.ts'
 export * from './unit-case.ts'
 
 const doomLint: Plugin<[], Root> = function () {

--- a/packages/doom/src/remark-lint/title-required.ts
+++ b/packages/doom/src/remark-lint/title-required.ts
@@ -1,0 +1,57 @@
+import type { Root } from 'mdast'
+import { toString } from 'mdast-util-to-string'
+import { lintRule } from 'unified-lint-rule'
+import { visitParents } from 'unist-util-visit-parents'
+import { parse } from 'yaml'
+
+export const titleRequired = lintRule<Root>(
+  'doom-lint:title-required',
+  (root, vfile) => {
+    let frontmatterTitle: string | undefined
+    let headingTitle: string | undefined
+    visitParents(root, (node, parents) => {
+      if (node.type === 'yaml') {
+        frontmatterTitle = (parse(node.value) as { title?: string }).title
+      }
+
+      function checkHeadingTitle(title: string) {
+        if (headingTitle) {
+          vfile.message(
+            'Multiple level 1 headings found, remove redundant heading or consolidate them into one.',
+            {
+              ancestors: [...parents, node],
+              place: node.position,
+            },
+          )
+        } else {
+          headingTitle = title
+        }
+      }
+
+      if (node.type === 'heading') {
+        if (node.depth === 1) {
+          checkHeadingTitle(toString(node))
+        }
+      } else if (node.type === 'html') {
+        const match = node.value.match(/<h1[^>]*>(.*?)<\/h1>/i)
+        if (match) {
+          checkHeadingTitle(match[1])
+        }
+      } else if (
+        node.type === 'mdxJsxFlowElement' ||
+        node.type === 'mdxJsxTextElement'
+      ) {
+        if (node.name === 'h1') {
+          checkHeadingTitle(toString(node))
+        }
+      }
+    })
+
+    if (!frontmatterTitle && !headingTitle) {
+      vfile.message(
+        'Title is required. Please add a title in the frontmatter or as a heading.',
+        root,
+      )
+    }
+  },
+)

--- a/packages/doom/src/remark-lint/title-required.ts
+++ b/packages/doom/src/remark-lint/title-required.ts
@@ -34,9 +34,10 @@ export const titleRequired = lintRule<Root>(
           checkHeadingTitle(toString(node))
         }
       } else if (node.type === 'html') {
-        const match = node.value.match(/<h1[^>]*>(.*?)<\/h1>/i)
-        if (match) {
-          checkHeadingTitle(match[1])
+        for (const [, title] of node.value.matchAll(
+          /<h1[^>]*>([\s\S]*?)<\/h1>/gi,
+        )) {
+          checkHeadingTitle(title)
         }
       } else if (
         node.type === 'mdxJsxFlowElement' ||

--- a/packages/doom/src/remark-lint/title-required.ts
+++ b/packages/doom/src/remark-lint/title-required.ts
@@ -11,7 +11,8 @@ export const titleRequired = lintRule<Root>(
     let headingTitle: string | undefined
     visitParents(root, (node, parents) => {
       if (node.type === 'yaml') {
-        frontmatterTitle = (parse(node.value) as { title?: string }).title
+        frontmatterTitle = (parse(node.value) as { title?: string } | null)
+          ?.title
       }
 
       function checkHeadingTitle(title: string) {

--- a/packages/doom/src/remarkrc.ts
+++ b/packages/doom/src/remarkrc.ts
@@ -20,6 +20,7 @@ import doomLint, {
   noUnmatchedAnchor,
   site,
   tableSize,
+  titleRequired,
   unitCase,
 } from './remark-lint/index.ts'
 
@@ -43,6 +44,7 @@ export default {
     noUnmatchedAnchor,
     site,
     tableSize,
+    titleRequired,
     unitCase,
   ],
 }

--- a/packages/doom/test/remark-lint/title-required.spec.ts
+++ b/packages/doom/test/remark-lint/title-required.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from '@rstest/core'
+
+import { lint, lintMdx } from './_helper.ts'
+
+import { titleRequired } from '#remark-lint/title-required.ts'
+
+describe('title-required', () => {
+  test('allows frontmatter title', async () => {
+    const messages = await lint(titleRequired, '---\ntitle: My Title\n---\n')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('allows markdown h1 heading', async () => {
+    const messages = await lint(titleRequired, '# My Title\n')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('allows html h1 element', async () => {
+    const messages = await lint(titleRequired, '<h1>My Title</h1>\n')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('allows mdx h1 element', async () => {
+    const messages = await lintMdx(titleRequired, '<h1>My Title</h1>\n')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('flags missing title', async () => {
+    const messages = await lint(titleRequired, 'Just some content\n')
+    expect(messages).toHaveLength(1)
+    expect(String(messages[0])).toContain('Title is required')
+  })
+
+  test('flags multiple h1 headings', async () => {
+    const messages = await lint(
+      titleRequired,
+      '# First Title\n\n# Second Title\n',
+    )
+    expect(messages).toHaveLength(1)
+    expect(String(messages[0])).toContain('Multiple level 1 headings')
+  })
+
+  test('flags multiple html h1 elements', async () => {
+    const messages = await lint(
+      titleRequired,
+      '<h1>First</h1>\n\n<h1>Second</h1>\n',
+    )
+    expect(messages).toHaveLength(1)
+    expect(String(messages[0])).toContain('Multiple level 1 headings')
+  })
+
+  test('flags multiple mdx h1 elements', async () => {
+    const messages = await lintMdx(
+      titleRequired,
+      '<h1>First</h1>\n\n<h1>Second</h1>\n',
+    )
+    expect(messages).toHaveLength(1)
+    expect(String(messages[0])).toContain('Multiple level 1 headings')
+  })
+
+  test('does not flag h2 or deeper headings as duplicates', async () => {
+    const messages = await lint(
+      titleRequired,
+      '# Main Title\n\n## Section 1\n\n## Section 2\n',
+    )
+    expect(messages).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Add new `title-required` lint rule to ensure documents have a title
- Rule checks for title in YAML frontmatter or as an h1 heading
- Detects and reports duplicate h1 headings (markdown, HTML, and MDX)
- Add comprehensive unit tests with 100% line coverage

## Changes

- `packages/doom/src/remark-lint/title-required.ts` - New lint rule implementation
- `packages/doom/src/remark-lint/index.ts` - Export the new rule
- `packages/doom/src/remarkrc.ts` - Enable the rule in doom's lint pipeline
- `packages/doom/test/remark-lint/title-required.spec.ts` - Unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new linting rule that enforces the presence of a document title. The rule validates titles from multiple sources including frontmatter, headings, HTML elements, and MDX components. Also detects and reports duplicate level-1 headings in documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->