### PR TITLE
feat(remark-lint): add file-naming rule

### DIFF
--- a/.changeset/fresh-houses-scream.md
+++ b/.changeset/fresh-houses-scream.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": minor
+---
+
+feat(remark-lint): add file-naming rule

--- a/openspec/changes/archive/2026-04-20-add-file-naming-rule/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-20-add-file-naming-rule/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/archive/2026-04-20-add-file-naming-rule/design.md
+++ b/openspec/changes/archive/2026-04-20-add-file-naming-rule/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The doom-lint suite has 17 remark-lint rules enforcing documentation quality. All rules follow the same pattern: `lintRule` from `unified-lint-rule` + `visitParents` from `unist-util-visit-parents`. Rules operate on mdast AST nodes, reporting via `vfile.message()`.
+
+The `file-naming` rule is unique: it validates the **vfile path** (filename), not AST content. It does not need to traverse the tree — it inspects `vfile.path` / `vfile.basename` / `vfile.dirname` at the root level.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Enforce lowercase-alphanumeric-underscore filenames for all `.md` / `.mdx` docs
+- For index files, validate the parent directory name instead
+- Integrate seamlessly into existing doom-lint preset
+
+**Non-Goals:**
+
+- Configurable patterns (hardcoded convention is sufficient)
+- Validating directory names beyond index file parents
+- Auto-fixing filenames
+
+## Decisions
+
+1. **Validate at root level, no AST traversal**: The rule checks `vfile.basename` (or parent dirname for index files) against a regex. No `visitParents` needed — just inspect the vfile metadata in the rule callback and return immediately.
+
+2. **Regex pattern**: `^_?[a-z0-9]+(_[a-z0-9]+)*$` applied to the filename stem (without extension). This allows: `foo`, `foo_bar`, `_foo`, `_foo_bar`. Disallows: `foo_`, `Foo`, `foo-bar`, `foo bar`.
+
+3. **Index file handling**: When `basename` is `index.md` or `index.mdx`, extract the last segment of `dirname` and validate that instead. If dirname is unavailable, skip validation.
+
+4. **Export as named const** (`fileNaming`) following existing pattern (e.g. `noDeepHeading`).
+
+## Risks / Trade-offs
+
+- **Existing docs may violate**: Existing documentation files might not conform. Mitigation: users can disable the rule per-file with `doom-lint` directive comments, or the rule can be adopted incrementally.
+- **No vfile.path in some contexts**: If the rule runs on stdin/virtual files without a path, it should silently skip. Mitigation: guard on `vfile.basename` existence.

--- a/openspec/changes/archive/2026-04-20-add-file-naming-rule/proposal.md
+++ b/openspec/changes/archive/2026-04-20-add-file-naming-rule/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Documentation filenames lack consistent naming enforcement. Files with uppercase letters, spaces, hyphens, or trailing underscores create URL inconsistencies, broken cross-references, and poor developer experience. A lint rule prevents these issues at authoring time.
+
+## What Changes
+
+- Add a new `doom-lint:file-naming` remark-lint rule that validates document filenames
+- Filenames must match `^_?[a-z0-9]+(_[a-z0-9]+)*\.(md|mdx)$` — lowercase letters, numbers, underscores only; may start with underscore but not end with one
+- For `index.md` / `index.mdx` files, validate the parent directory name (basename) instead
+- Integrate the rule into the existing doom-lint preset
+
+## Capabilities
+
+### New Capabilities
+
+- `file-naming-rule`: Remark-lint rule enforcing document filename conventions (lowercase, numbers, underscores only)
+
+### Modified Capabilities
+
+## Impact
+
+- `packages/doom/src/remark-lint/` — new rule file + index.ts re-export
+- `packages/doom/test/remark-lint/` — new test file
+- No cross-package impact; no new dependencies; no virtual modules; type-coverage unaffected

--- a/openspec/changes/archive/2026-04-20-add-file-naming-rule/specs/file-naming-rule/spec.md
+++ b/openspec/changes/archive/2026-04-20-add-file-naming-rule/specs/file-naming-rule/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Validate document filename pattern
+
+The rule SHALL validate that document filenames contain only lowercase English letters (`a-z`), digits (`0-9`), and underscores (`_`). The filename (without extension) MUST match the pattern `^_?[a-z0-9]+(_[a-z0-9]+)*$`.
+
+#### Scenario: Valid simple filename
+
+- **WHEN** the document filename is `getting_started.md`
+- **THEN** no lint warning is reported
+
+#### Scenario: Valid filename starting with underscore
+
+- **WHEN** the document filename is `_sidebar.md`
+- **THEN** no lint warning is reported
+
+#### Scenario: Invalid filename with uppercase letters
+
+- **WHEN** the document filename is `GettingStarted.md`
+- **THEN** a lint warning is reported indicating the filename does not match the required pattern
+
+#### Scenario: Invalid filename with hyphens
+
+- **WHEN** the document filename is `getting-started.md`
+- **THEN** a lint warning is reported indicating the filename does not match the required pattern
+
+#### Scenario: Invalid filename ending with underscore
+
+- **WHEN** the document filename is `getting_started_.md`
+- **THEN** a lint warning is reported indicating the filename does not match the required pattern
+
+#### Scenario: Valid mdx filename
+
+- **WHEN** the document filename is `my_component.mdx`
+- **THEN** no lint warning is reported
+
+### Requirement: Index files validate parent directory name
+
+For `index.md` and `index.mdx` files, the rule SHALL validate the parent directory name (basename of dirname) instead of the filename itself, using the same pattern.
+
+#### Scenario: Index file with valid parent directory
+
+- **WHEN** the document path is `docs/getting_started/index.md`
+- **THEN** no lint warning is reported
+
+#### Scenario: Index file with invalid parent directory
+
+- **WHEN** the document path is `docs/Getting-Started/index.md`
+- **THEN** a lint warning is reported indicating the directory name does not match the required pattern
+
+#### Scenario: Index file at root (no parent directory)
+
+- **WHEN** the document is `index.md` with no parent directory information available
+- **THEN** no lint warning is reported (skip validation)
+
+### Requirement: Skip validation when path unavailable
+
+The rule SHALL silently skip validation when the vfile has no basename (e.g., stdin or virtual files).
+
+#### Scenario: Virtual file with no path
+
+- **WHEN** the document has no file path (e.g., piped from stdin)
+- **THEN** no lint warning is reported and no error is thrown

--- a/openspec/changes/archive/2026-04-20-add-file-naming-rule/tasks.md
+++ b/openspec/changes/archive/2026-04-20-add-file-naming-rule/tasks.md
@@ -1,0 +1,15 @@
+## 1. Core Implementation
+
+- [x] 1.1 Create `packages/doom/src/remark-lint/file-naming.ts` implementing the `doom-lint:file-naming` rule using `lintRule` from `unified-lint-rule`. Validate `vfile.basename` stem against `^_?[a-z0-9]+(_[a-z0-9]+)*$`. For `index.md`/`index.mdx`, validate last segment of `vfile.dirname`. Skip if no basename available.
+- [x] 1.2 Export `fileNaming` from `packages/doom/src/remark-lint/index.ts` via `export * from './file-naming.ts'`
+
+## 2. Testing
+
+- [x] 2.1 Create `packages/doom/test/remark-lint/file-naming.spec.ts` with test cases covering: valid filenames, underscore prefix, uppercase rejection, hyphen rejection, trailing underscore rejection, mdx support, index file parent directory validation, missing path skip
+
+## 3. Validation
+
+- [x] 3.1 Run `yarn build` and verify no compilation errors
+- [x] 3.2 Run `yarn lint` and verify no lint errors
+- [x] 3.3 Run `yarn test` and verify all tests pass including new file-naming tests
+- [x] 3.4 Run `yarn typecov` and verify 100% type coverage maintained

--- a/packages/doom/src/remark-lint/file-naming.ts
+++ b/packages/doom/src/remark-lint/file-naming.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+
+import type { Root } from 'mdast'
+import { lintRule } from 'unified-lint-rule'
+
+import { getConfig } from './utils.ts'
+
+const VALID_NAME_PATTERN = /^_?[a-z0-9]+(?:_[a-z0-9]+)*$/
+
+export const fileNaming = lintRule<Root>(
+  'doom-lint:file-naming',
+  async (_root, vfile) => {
+    if (!vfile.path) {
+      return
+    }
+
+    const { config } = await getConfig()
+
+    const relativePath = path.relative(config.root!, vfile.path)
+
+    const prefix = config.lang ? config.lang + '/' : ''
+
+    // Ignore files outside the root directory
+    if (
+      relativePath.startsWith('..') ||
+      relativePath === `${prefix}index.md` ||
+      relativePath === `${prefix}index.mdx` ||
+      relativePath.startsWith(`${prefix}apis/`)
+    ) {
+      return
+    }
+
+    const stem = vfile.stem!
+    const isIndex = stem === 'index'
+    const basename = isIndex ? path.basename(vfile.dirname!) : stem
+
+    if (!VALID_NAME_PATTERN.test(basename)) {
+      vfile.message(
+        `${isIndex ? 'Directory name' : 'Filename'} "${basename}" does not match the required pattern: lowercase letters, numbers, and underscores only, must not end with underscore`,
+      )
+    }
+  },
+)

--- a/packages/doom/src/remark-lint/index.ts
+++ b/packages/doom/src/remark-lint/index.ts
@@ -3,6 +3,7 @@ import remarkMessageControl from 'remark-message-control'
 import type { Plugin } from 'unified'
 
 export * from './check-dead-links.ts'
+export * from './file-naming.ts'
 export * from './list-item-punctuation.ts'
 export * from './list-item-size.ts'
 export * from './list-table-introduction.ts'

--- a/packages/doom/src/remarkrc.ts
+++ b/packages/doom/src/remarkrc.ts
@@ -13,6 +13,7 @@ import remarkLintNoHiddenTableCell from 'remark-lint-no-hidden-table-cell'
 
 import doomLint, {
   checkDeadLinks,
+  fileNaming,
   noDeepHeading,
   noDeepList,
   noMultiOpenAPIPaths,
@@ -37,6 +38,7 @@ export default {
     remarkLintNoHiddenTableCell,
     doomLint,
     checkDeadLinks,
+    fileNaming,
     noDeepHeading,
     noDeepList,
     noMultiOpenAPIPaths,

--- a/packages/doom/test/remark-lint/file-naming.spec.ts
+++ b/packages/doom/test/remark-lint/file-naming.spec.ts
@@ -1,0 +1,96 @@
+import path from 'node:path'
+
+import { describe, expect, test } from '@rstest/core'
+import remarkParse from 'remark-parse'
+import remarkStringify from 'remark-stringify'
+import { unified } from 'unified'
+import { VFile } from 'vfile'
+
+import { fileNaming } from '#remark-lint/file-naming.ts'
+import { getConfig } from '#remark-lint/utils.ts'
+
+const processor = unified().use(remarkParse).use(remarkStringify)
+
+const { config } = await getConfig()
+
+async function lintWithPath(filePath: string) {
+  const file = await processor()
+    .use(fileNaming as unknown as Parameters<typeof processor.use>[0])
+    .process(
+      new VFile({
+        value: '# Test\n',
+        path: path.resolve(config.root!, filePath),
+      }),
+    )
+  return file.messages
+}
+
+describe('file-naming', () => {
+  test('allows valid simple filename', async () => {
+    const messages = await lintWithPath('getting_started.md')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('allows valid filename with numbers', async () => {
+    const messages = await lintWithPath('chapter1.md')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('allows underscore prefix', async () => {
+    const messages = await lintWithPath('_sidebar.md')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('allows mdx extension', async () => {
+    const messages = await lintWithPath('my_component.mdx')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('flags uppercase letters', async () => {
+    const messages = await lintWithPath('GettingStarted.md')
+    expect(messages).toHaveLength(1)
+    expect(String(messages[0])).toContain('GettingStarted')
+  })
+
+  test('flags hyphens', async () => {
+    const messages = await lintWithPath('getting-started.md')
+    expect(messages).toHaveLength(1)
+    expect(String(messages[0])).toContain('getting-started')
+  })
+
+  test('flags trailing underscore', async () => {
+    const messages = await lintWithPath('getting_started_.md')
+    expect(messages).toHaveLength(1)
+    expect(String(messages[0])).toContain('getting_started_')
+  })
+
+  test('validates parent directory for index.md', async () => {
+    const messages = await lintWithPath('getting_started/index.md')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('flags invalid parent directory for index.md', async () => {
+    const messages = await lintWithPath('Getting-Started/index.md')
+    expect(messages).toHaveLength(1)
+    expect(String(messages[0])).toContain('Getting-Started')
+  })
+
+  test('validates parent directory for index.mdx', async () => {
+    const messages = await lintWithPath('my_section/index.mdx')
+    expect(messages).toHaveLength(0)
+  })
+
+  test('ignores files in apis directory', async () => {
+    const messages = await lintWithPath(
+      `${config.lang ? config.lang + '/' : ''}apis/Deployment.mdx`,
+    )
+    expect(messages).toHaveLength(0)
+  })
+
+  test('skips when no basename available', async () => {
+    const file = await processor()
+      .use(fileNaming as unknown as Parameters<typeof processor.use>[0])
+      .process(new VFile({ value: '# Test\n' }))
+    expect(file.messages).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Add new `doom-lint:file-naming` remark-lint rule that enforces document filenames contain only lowercase letters, numbers, and underscores
- Filenames may start with underscore but cannot end with one (pattern: `^_?[a-z0-9]+(?:_[a-z0-9]+)*$`)
- For `index.md`/`index.mdx` files, validates the parent directory name instead
- Includes 11 test cases covering valid/invalid filenames, index file handling, and edge cases
- Build, lint, tests, and 100% type coverage all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `doom-lint:file-naming` rule to enforce filename conventions, requiring lowercase alphanumeric characters with optional underscores and underscore-separated segments
  * Special handling for `index.md`/`index.mdx` files to validate parent directory naming

* **Tests**
  * Added comprehensive test coverage for the file naming rule validation scenarios

* **Chores**
  * Integrated the new rule into the doom-lint preset

<!-- end of auto-generated comment: release notes by coderabbit.ai -->