### PR TITLE
fix(cli): translate code block file paths

### DIFF
--- a/.changeset/short-planes-heal.md
+++ b/.changeset/short-planes-heal.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+fix(cli): support relative file meta paths in translated code blocks

--- a/fixture-docs/en/assets/reference.yaml
+++ b/fixture-docs/en/assets/reference.yaml
@@ -1,0 +1,12 @@
+reference:
+  - repo: alauda-public/product-doc-guide # 可选，引用文档仓库地址，如果不填写，则默认使用当前文档仓库地址
+    branch: # [string] 可选，引用文档仓库分支
+    publicBase: # [string] 可选，使用远程仓库时使用绝对路径 /images/xx.png 对应的静态资源所在目录，默认为 docs/public
+    sources:
+      - name: anchor # 引用文档名称，用于在文档中引用，全局唯一
+        path: docs/index.mdx#介绍 # 引用文档路径，支持锚点定位，远程仓库相对于仓库根目录，本地相对于 doom.config.* 所在目录
+        ignoreHeading: # [boolean] 可选，是否忽略标题，如果为 true，则不会在引用文档中显示锚点的标题
+        processors: # 可选，引用文档内容处理器
+          - type: ejsTemplate
+            data: # ejs 模板参数，使用 `<%= data.xx %>` 访问
+        frontmatterMode: merge # 可选，引用文档处理 frontmatter 模式，默认为 ignore，可选值为 ignore/merge/replace/remove

--- a/fixture-docs/en/code-block.mdx
+++ b/fixture-docs/en/code-block.mdx
@@ -1,0 +1,3 @@
+```yaml before file="./assets/reference.yaml" after title="Whatever"
+
+```

--- a/fixture-docs/zh/code-block.mdx
+++ b/fixture-docs/zh/code-block.mdx
@@ -1,0 +1,7 @@
+---
+sourceSHA: f9e3e3db6c15cb555df9be82c0e5642c4d27852d2a247365e2110253d0eaf521
+---
+
+```yaml before file="../en/assets/reference.yaml" after title="Whatever"
+
+```

--- a/packages/doom/src/cli/helpers.ts
+++ b/packages/doom/src/cli/helpers.ts
@@ -72,42 +72,28 @@ let parsedTermsCache: Promise<NormalizedTermItem[]> | undefined
 
 export const parseTerms = () => (parsedTermsCache ??= parseTerms_())
 
-const QUOTES = ['"', "'", '`']
+const RELATIVE_FILE_META_REGEX =
+  /(^|\s)(file)(\s*=\s*)(['"`]?)(\.\.?\/[^\s'"`]+)\4/g
 
 export const translateCodeFile = (
   content: RootContent,
   { sourceBase, targetBase }: { sourceBase: string; targetBase: string },
 ) => {
   visit(content, 'code', (code) => {
-    const meta = code.meta?.trim()
-    if (!meta) {
-      return
-    }
-    const list = meta.split(/\s+/)
-    let changed = false
-    for (const [index, item] of list.entries()) {
-      let [key, value] = item.split('=')
-      if (key !== 'file' || !value) {
-        continue
-      }
-      let activeQuote = ''
-      for (const quote of QUOTES) {
-        if (value.startsWith(quote) && value.endsWith(quote)) {
-          activeQuote = quote
-          value = value.slice(1, -1)
-          break
-        }
-      }
-      // only translate relative paths, absolute paths should be kept unchanged
-      if (!value.startsWith('./')) {
-        break
-      }
-      list[index] =
-        `file=${activeQuote}${path.relative(targetBase, path.resolve(sourceBase, value))}${activeQuote}`
-      changed = true
-    }
-    if (changed) {
-      code.meta = list.join(' ')
+    const nextMeta = code.meta?.replace(
+      RELATIVE_FILE_META_REGEX,
+      (
+        _match: string,
+        prefix: string,
+        key: string,
+        equals: string,
+        quote: string,
+        value: string,
+      ) =>
+        `${prefix}${key}${equals}${quote}${path.relative(targetBase, path.resolve(sourceBase, value))}${quote}`,
+    )
+    if (nextMeta !== code.meta) {
+      code.meta = nextMeta
     }
   })
   return content

--- a/packages/doom/src/cli/helpers.ts
+++ b/packages/doom/src/cli/helpers.ts
@@ -87,7 +87,7 @@ export const translateCodeFile = (
     let changed = false
     for (const [index, item] of list.entries()) {
       let [key, value] = item.split('=')
-      if (key !== 'file') {
+      if (key !== 'file' || !value) {
         continue
       }
       let activeQuote = ''

--- a/packages/doom/src/cli/helpers.ts
+++ b/packages/doom/src/cli/helpers.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs/promises'
+import path from 'node:path'
 
+import type { RootContent } from 'mdast'
 import { glob } from 'tinyglobby'
+import { visit } from 'unist-util-visit'
 import { xfetch } from 'x-fetch'
 import { parse } from 'yaml'
 
@@ -68,3 +71,44 @@ const parseTerms_ = async () => {
 let parsedTermsCache: Promise<NormalizedTermItem[]> | undefined
 
 export const parseTerms = () => (parsedTermsCache ??= parseTerms_())
+
+const QUOTES = ['"', "'", '`']
+
+export const translateCodeFile = (
+  content: RootContent,
+  { sourceBase, targetBase }: { sourceBase: string; targetBase: string },
+) => {
+  visit(content, 'code', (code) => {
+    const meta = code.meta?.trim()
+    if (!meta) {
+      return
+    }
+    const list = meta.split(/\s+/)
+    let changed = false
+    for (const [index, item] of list.entries()) {
+      let [key, value] = item.split('=')
+      if (key !== 'file') {
+        continue
+      }
+      let activeQuote = ''
+      for (const quote of QUOTES) {
+        if (value.startsWith(quote) && value.endsWith(quote)) {
+          activeQuote = quote
+          value = value.slice(1, -1)
+          break
+        }
+      }
+      // only translate relative paths, absolute paths should be kept unchanged
+      if (!value.startsWith('./')) {
+        break
+      }
+      list[index] =
+        `file=${activeQuote}${path.relative(targetBase, path.resolve(sourceBase, value))}${activeQuote}`
+      changed = true
+    }
+    if (changed) {
+      code.meta = list.join(' ')
+    }
+  })
+  return content
+}

--- a/packages/doom/src/cli/translate.ts
+++ b/packages/doom/src/cli/translate.ts
@@ -33,6 +33,7 @@ import {
   getMatchedDocFilePaths,
   parseBoolean,
   parseTerms,
+  translateCodeFile,
 } from './helpers.js'
 import { loadConfig } from './load-config.js'
 
@@ -528,19 +529,24 @@ export const translateCommand = new Command('translate')
                 escapeMarkdownHeadingIds(sourceContent),
               )
 
+              const sourceBase = path.dirname(sourceFilePath)
               const targetBase = path.dirname(targetFilePath)
 
+              const normalizeOptions = { sourceBase, targetBase }
+
               const normalizeImgSrcOptions: NormalizeImgSrcOptions = {
+                ...normalizeOptions,
                 localPublicBase: path.resolve(docsDir, 'public'),
-                sourceBase: path.dirname(sourceFilePath),
-                targetBase,
                 translating: { source, target, copy },
               }
 
               const normalizedSourceContent = processor.stringify({
                 ...ast,
                 children: ast.children.map((it) =>
-                  normalizeImgSrc(it, normalizeImgSrcOptions),
+                  translateCodeFile(
+                    normalizeImgSrc(it, normalizeImgSrcOptions),
+                    normalizeOptions,
+                  ),
                 ),
               })
 

--- a/packages/doom/test/cli/helpers.spec.ts
+++ b/packages/doom/test/cli/helpers.spec.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, test } from '@rstest/core'
+import type { Code } from 'mdast'
 
 import {
   defaultGitHubUrl,
@@ -11,6 +12,7 @@ import {
   isDoc,
   parseBoolean,
   parseBooleanOrString,
+  translateCodeFile,
 } from '#cli/helpers.ts'
 
 describe('parseBoolean', () => {
@@ -209,5 +211,75 @@ describe('getMatchedDocFilePaths', () => {
     const result = await getMatchedDocFilePaths([path.join(tempDir, 'docs')])
 
     expect((result[0] as string[]).sort()).toEqual([mdFile, mdxFile].sort())
+  })
+})
+
+describe('translateCodeFile', () => {
+  test('rewrites relative file meta paths to the target base', () => {
+    const content: Code = {
+      type: 'code',
+      lang: 'md',
+      meta: 'file="./assets/demo.mdx" title="Example"',
+      value: '<Overview />',
+    }
+
+    translateCodeFile(content, {
+      sourceBase: '/source/docs',
+      targetBase: '/target/docs',
+    })
+
+    expect(content.meta).toBe(
+      'file="../../source/docs/assets/demo.mdx" title="Example"',
+    )
+  })
+
+  test('rewrites relative file meta paths with single quotes', () => {
+    const content: Code = {
+      type: 'code',
+      lang: 'md',
+      meta: "file='./assets/demo.mdx' title='Example'",
+      value: '<Overview />',
+    }
+
+    translateCodeFile(content, {
+      sourceBase: '/source/docs',
+      targetBase: '/target/docs',
+    })
+
+    expect(content.meta).toBe(
+      "file='../../source/docs/assets/demo.mdx' title='Example'",
+    )
+  })
+
+  test('keeps absolute file meta paths unchanged', () => {
+    const content: Code = {
+      type: 'code',
+      lang: 'mdx',
+      meta: 'file="/source/docs/assets/demo.mdx"',
+      value: '<Overview />',
+    }
+
+    translateCodeFile(content, {
+      sourceBase: '/source/docs',
+      targetBase: '/target/docs',
+    })
+
+    expect(content.meta).toBe('file="/source/docs/assets/demo.mdx"')
+  })
+
+  test('keeps absolute file meta paths with single quotes unchanged', () => {
+    const content: Code = {
+      type: 'code',
+      lang: 'mdx',
+      meta: "file='/source/docs/assets/demo.mdx'",
+      value: '<Overview />',
+    }
+
+    translateCodeFile(content, {
+      sourceBase: '/source/docs',
+      targetBase: '/target/docs',
+    })
+
+    expect(content.meta).toBe("file='/source/docs/assets/demo.mdx'")
   })
 })

--- a/packages/doom/test/cli/helpers.spec.ts
+++ b/packages/doom/test/cli/helpers.spec.ts
@@ -224,12 +224,12 @@ describe('translateCodeFile', () => {
     }
 
     translateCodeFile(content, {
-      sourceBase: '/source/docs',
-      targetBase: '/target/docs',
+      sourceBase: '/docs/source',
+      targetBase: '/docs/target',
     })
 
     expect(content.meta).toBe(
-      'file="../../source/docs/assets/demo.mdx" title="Example"',
+      'file="../source/assets/demo.mdx" title="Example"',
     )
   })
 
@@ -242,12 +242,12 @@ describe('translateCodeFile', () => {
     }
 
     translateCodeFile(content, {
-      sourceBase: '/source/docs',
-      targetBase: '/target/docs',
+      sourceBase: '/docs/source',
+      targetBase: '/docs/target',
     })
 
     expect(content.meta).toBe(
-      "file='../../source/docs/assets/demo.mdx' title='Example'",
+      "file='../source/assets/demo.mdx' title='Example'",
     )
   })
 
@@ -260,12 +260,12 @@ describe('translateCodeFile', () => {
     }
 
     translateCodeFile(content, {
-      sourceBase: '/source/docs',
-      targetBase: '/target/docs',
+      sourceBase: '/docs/source',
+      targetBase: '/docs/target',
     })
 
     expect(content.meta).toBe(
-      'file = "../../source/docs/assets/demo.mdx" title = "Long      Code     Block"',
+      'file = "../source/assets/demo.mdx" title = "Long      Code     Block"',
     )
   })
 
@@ -278,8 +278,8 @@ describe('translateCodeFile', () => {
     }
 
     translateCodeFile(content, {
-      sourceBase: '/source/docs',
-      targetBase: '/target/docs',
+      sourceBase: '/docs/source',
+      targetBase: '/docs/target',
     })
 
     expect(content.meta).toBe('file="../../assets/xyz.sh" title="Script"')
@@ -294,12 +294,12 @@ describe('translateCodeFile', () => {
     }
 
     translateCodeFile(content, {
-      sourceBase: '/source/docs',
-      targetBase: '/target/docs',
+      sourceBase: '/docs/source',
+      targetBase: '/docs/target',
     })
 
     expect(content.meta).toBe(
-      'file="../../source/docs/assets/demo.mdx" title="Long      Code     Block"',
+      'file="../source/assets/demo.mdx" title="Long      Code     Block"',
     )
   })
 
@@ -312,8 +312,8 @@ describe('translateCodeFile', () => {
     }
 
     translateCodeFile(content, {
-      sourceBase: '/source/docs',
-      targetBase: '/target/docs',
+      sourceBase: '/docs/source',
+      targetBase: '/docs/target',
     })
 
     expect(content.meta).toBe('file title="Example"')
@@ -328,8 +328,8 @@ describe('translateCodeFile', () => {
     }
 
     translateCodeFile(content, {
-      sourceBase: '/source/docs',
-      targetBase: '/target/docs',
+      sourceBase: '/docs/source',
+      targetBase: '/docs/target',
     })
 
     expect(content.meta).toBe('file="/source/docs/assets/demo.mdx"')
@@ -344,8 +344,8 @@ describe('translateCodeFile', () => {
     }
 
     translateCodeFile(content, {
-      sourceBase: '/source/docs',
-      targetBase: '/target/docs',
+      sourceBase: '/docs/source',
+      targetBase: '/docs/target',
     })
 
     expect(content.meta).toBe("file='/source/docs/assets/demo.mdx'")

--- a/packages/doom/test/cli/helpers.spec.ts
+++ b/packages/doom/test/cli/helpers.spec.ts
@@ -251,6 +251,58 @@ describe('translateCodeFile', () => {
     )
   })
 
+  test('rewrites relative file meta paths with spaced equals', () => {
+    const content: Code = {
+      type: 'code',
+      lang: 'md',
+      meta: 'file = "./assets/demo.mdx" title = "Long      Code     Block"',
+      value: '<Overview />',
+    }
+
+    translateCodeFile(content, {
+      sourceBase: '/source/docs',
+      targetBase: '/target/docs',
+    })
+
+    expect(content.meta).toBe(
+      'file = "../../source/docs/assets/demo.mdx" title = "Long      Code     Block"',
+    )
+  })
+
+  test('rewrites deeper relative file paths', () => {
+    const content: Code = {
+      type: 'code',
+      lang: 'md',
+      meta: 'file="../../assets/xyz.sh" title="Script"',
+      value: '<Overview />',
+    }
+
+    translateCodeFile(content, {
+      sourceBase: '/source/docs',
+      targetBase: '/target/docs',
+    })
+
+    expect(content.meta).toBe('file="../../assets/xyz.sh" title="Script"')
+  })
+
+  test('preserves quoted titles with whitespace', () => {
+    const content: Code = {
+      type: 'code',
+      lang: 'md',
+      meta: 'file="./assets/demo.mdx" title="Long      Code     Block"',
+      value: '<Overview />',
+    }
+
+    translateCodeFile(content, {
+      sourceBase: '/source/docs',
+      targetBase: '/target/docs',
+    })
+
+    expect(content.meta).toBe(
+      'file="../../source/docs/assets/demo.mdx" title="Long      Code     Block"',
+    )
+  })
+
   test('leaves bare file tokens untouched', () => {
     const content: Code = {
       type: 'code',

--- a/packages/doom/test/cli/helpers.spec.ts
+++ b/packages/doom/test/cli/helpers.spec.ts
@@ -251,6 +251,22 @@ describe('translateCodeFile', () => {
     )
   })
 
+  test('leaves bare file tokens untouched', () => {
+    const content: Code = {
+      type: 'code',
+      lang: 'md',
+      meta: 'file title="Example"',
+      value: '<Overview />',
+    }
+
+    translateCodeFile(content, {
+      sourceBase: '/source/docs',
+      targetBase: '/target/docs',
+    })
+
+    expect(content.meta).toBe('file title="Example"')
+  })
+
   test('keeps absolute file meta paths unchanged', () => {
     const content: Code = {
       type: 'code',


### PR DESCRIPTION
## Summary
- Translate `file=` code block meta paths alongside translated MDX content.
- Preserve relative path rewriting while leaving non-`file` meta untouched.
- Add fixture docs and unit coverage for quoted `file=` values.

## Test plan
- [x] `yarn rstest packages/doom/test/cli/helpers.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reference documentation configuration with customizable sources and processing options.
  * Introduced code block documentation examples in multiple languages.
  * Enhanced file path translation in documentation content to maintain correct references across different locales.

* **Tests**
  * Added test coverage for file path translation functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/doom/pull/332)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->