### PR TITLE
[codex] fix MDX global component no-undef lint

### DIFF
--- a/.changeset/fix-mdx-global-component-lint.md
+++ b/.changeset/fix-mdx-global-component-lint.md
@@ -1,0 +1,5 @@
+---
+"@alauda/doom": patch
+---
+
+Declare Doom's MDX global components in the built-in ESLint config so `doom lint` does not report them as undefined JSX identifiers.

--- a/packages/doom/src/eslint.ts
+++ b/packages/doom/src/eslint.ts
@@ -1,4 +1,6 @@
+import fs from 'node:fs'
 import { createRequire } from 'node:module'
+import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import type { Options } from '@cspell/eslint-plugin'
@@ -13,16 +15,42 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 import { loadConfig } from './cli/load-config.js'
+import { getGlobalComponentNames } from './plugins/global/components.js'
+import { pkgResolve } from './utils/index.js'
 
 const cjsRequire = createRequire(import.meta.url)
 
-let remarkConfigPath: string
+let remarkConfigPath: string | undefined
+
+const isLoadableRemarkConfigPath = (filepath: string) =>
+  ['.cjs', '.js', '.mjs'].includes(path.extname(filepath))
 
 try {
-  remarkConfigPath = fileURLToPath(import.meta.resolve('./remarkrc.js'))
+  const resolvedRemarkConfigPath = fileURLToPath(
+    import.meta.resolve('./remarkrc.js'),
+  )
+  if (isLoadableRemarkConfigPath(resolvedRemarkConfigPath)) {
+    remarkConfigPath = resolvedRemarkConfigPath
+  }
 } catch {
-  remarkConfigPath = cjsRequire.resolve('./remarkrc.js')
+  try {
+    const resolvedRemarkConfigPath = cjsRequire.resolve('./remarkrc.js')
+    if (isLoadableRemarkConfigPath(resolvedRemarkConfigPath)) {
+      remarkConfigPath = resolvedRemarkConfigPath
+    }
+  } catch {
+    remarkConfigPath = undefined
+  }
 }
+
+const builtRemarkConfigPath = pkgResolve('lib/remarkrc.js')
+if (!remarkConfigPath && fs.existsSync(builtRemarkConfigPath)) {
+  remarkConfigPath = builtRemarkConfigPath
+}
+
+const globalComponentGlobals = Object.fromEntries(
+  getGlobalComponentNames().map((name) => [name, 'readonly']),
+) as Record<string, 'readonly'>
 
 async function doom(
   userConfig?: UserConfig | null,
@@ -64,7 +92,7 @@ async function doom(userConfigOrRoot?: UserConfig | string | null | URL) {
       languageOptions: {
         globals: globals.browser,
         parserOptions: {
-          remarkConfigPath,
+          ...(remarkConfigPath && { remarkConfigPath }),
         },
       },
       rules: cspellEnabled
@@ -81,6 +109,9 @@ async function doom(userConfigOrRoot?: UserConfig | string | null | URL) {
     },
     {
       files: ['**/*.mdx'],
+      languageOptions: {
+        globals: globalComponentGlobals,
+      },
       rules: {
         '@eslint-react/jsx-no-children-prop': 'off',
         '@eslint-react/rules-of-hooks': 'off',

--- a/packages/doom/src/plugins/global/components.ts
+++ b/packages/doom/src/plugins/global/components.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { baseResolve } from '../../utils/index.ts'
+
+const componentsDir = baseResolve('runtime/components')
+
+const isGlobalComponentFile = (file: string) => {
+  const basename = path.basename(file, path.extname(file))
+  return (
+    !basename.startsWith('_') &&
+    !basename.endsWith('.d') &&
+    basename !== 'index'
+  )
+}
+
+export const getGlobalComponentFiles = () =>
+  fs
+    .readdirSync(componentsDir)
+    .filter(isGlobalComponentFile)
+    .map((file) => path.resolve(componentsDir, file))
+
+export const getGlobalComponentNames = () =>
+  fs
+    .readdirSync(componentsDir)
+    .filter(isGlobalComponentFile)
+    .map((file) => path.basename(file, path.extname(file)))

--- a/packages/doom/src/plugins/global/index.ts
+++ b/packages/doom/src/plugins/global/index.ts
@@ -8,8 +8,9 @@ import { ACP_BASE, type DoomSite } from '../../shared/index.ts'
 import type { ExportItem } from '../../types.ts'
 import { baseResolve, pkgResolve } from '../../utils/index.ts'
 
+import { getGlobalComponentFiles } from './components.ts'
+
 const globalComponentsDir = baseResolve('global')
-const componentsDir = baseResolve('runtime/components')
 
 export interface GlobalPluginOptions {
   version?: string
@@ -39,17 +40,7 @@ export const globalPlugin = ({
       .readdirSync(globalComponentsDir, 'utf8')
       .map((component) => path.resolve(globalComponentsDir, component)),
     markdown: {
-      globalComponents: fs
-        .readdirSync(componentsDir)
-        .filter((file) => {
-          const basename = path.basename(file, path.extname(file))
-          return (
-            !basename.startsWith('_') &&
-            !basename.endsWith('.d') &&
-            basename !== 'index'
-          )
-        })
-        .map((file) => path.resolve(componentsDir, file)),
+      globalComponents: getGlobalComponentFiles(),
     },
     addRuntimeModules(config, isProd) {
       return {

--- a/packages/doom/test/eslint.spec.ts
+++ b/packages/doom/test/eslint.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from '@rstest/core'
+import { ESLint } from 'eslint'
+
+import doom from '#eslint.ts'
+
+type ESLintOptions = NonNullable<ConstructorParameters<typeof ESLint>[0]>
+
+const lintMdx = async (value: string) => {
+  const overrideConfig = [
+    ...(await doom(null)),
+    {
+      files: ['**/*.mdx'],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: {
+            jsx: true,
+          },
+          ignoreRemarkConfig: true,
+        },
+      },
+      rules: {
+        'mdx/remark': 'off',
+      },
+    },
+  ] as unknown as ESLintOptions['overrideConfig']
+
+  const eslint = new ESLint({
+    cwd: process.cwd(),
+    overrideConfigFile: true,
+    overrideConfig,
+  })
+
+  const [result] = await eslint.lintText(value, {
+    filePath: 'docs/en/test.mdx',
+  })
+
+  return result.messages
+}
+
+describe('doom eslint config', () => {
+  test('allows doom global MDX components without local imports', async () => {
+    const messages = await lintMdx(
+      [
+        '# Title',
+        '',
+        '<Overview />',
+        '<Steps>',
+        '  <Term name="product" />',
+        '</Steps>',
+        '',
+      ].join('\n'),
+    )
+
+    expect(messages).not.toContainEqual(
+      expect.objectContaining({ ruleId: 'no-undef' }),
+    )
+  })
+
+  test('still reports unknown MDX component references', async () => {
+    const messages = await lintMdx('# Title\n\n<UnknownComponent />\n')
+
+    expect(messages).toContainEqual(
+      expect.objectContaining({
+        ruleId: 'no-undef',
+        message: "'UnknownComponent' is not defined.",
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- declare Doom runtime MDX global components as readonly globals in the built-in ESLint config
- share the global component discovery logic with the Rspress global plugin so lint/build stay in sync
- add regression coverage that permits known Doom MDX globals while still reporting unknown components

## Root Cause

After the ESLint 10 upgrade, JSX component identifiers in MDX are included in the scope analysis used by `no-undef`. Doom injects components such as `Overview`, `Steps`, `K8sCrd`, and `ExternalSiteLink` through Rspress `markdown.globalComponents`, so document authors do not import them locally. Without declaring those names as globals, `doom lint` reports valid MDX component usage as undefined.

## Validation

- `yarn test packages/doom/test/eslint.spec.ts`
- `yarn build`
- `yarn eslint packages/doom/src/eslint.ts packages/doom/src/plugins/global/index.ts packages/doom/src/plugins/global/components.ts packages/doom/test/eslint.spec.ts`
- `yarn doom lint fixture-docs --no-cspell -g 'en/test/managedtap.mdx'`
- validated against real vendor docs using clean worktrees from current remote main/master snapshots; the MDX global component `no-undef` errors are gone

## Notes

Clean vendor validation also shows independent failures from `doom-lint-no-legacy-os-names` on current `aml-docs` and `acp-docs` master content. That rule was introduced separately in `@alauda/doom@2.5.3` and is not part of the ESLint 10 global component regression fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MDX global components are now recognized in the built-in lint configuration, so common component tags can be used without triggering undefined identifier errors.
  * Global component detection is now handled more reliably when generating lint settings.

* **Bug Fixes**
  * Improved lint behavior for MDX files so valid components are no longer reported as undefined.
  * Preserved warnings for truly unknown component names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->